### PR TITLE
Remove Manage Messages perms requirement by only deleting own reactions

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -96,7 +96,7 @@ export default class {
     });
 
     this.client.on('ready', async () => {
-      console.log(`Ready! Invite the bot with https://discordapp.com/oauth2/authorize?client_id=${this.clientId}&scope=bot&permissions=36760640`);
+      console.log(`Ready! Invite the bot with https://discordapp.com/oauth2/authorize?client_id=${this.clientId}&scope=bot&permissions=36752448`);
     });
 
     this.client.on('error', console.error);

--- a/src/utils/loading-message.ts
+++ b/src/utils/loading-message.ts
@@ -43,7 +43,7 @@ export default class {
 
           if (reactionToRemove) {
             // eslint-disable-next-line no-await-in-loop
-            await reactionToRemove.remove();
+            await reactionToRemove.users.remove(this.msg.client.user!.id);
           } else {
             isRemoving = false;
           }


### PR DESCRIPTION
Currently, the bot requires Manage Messages, but I think the only reason it requires this moderation privilege is to `removeAll()` the cow emoji reacts. (I might be wrong on that, please say something if it needs it for something else).

Following the principle of least privilege, the bot shouldn't require any privileges that a typical Discord member doesn't have.

Moreover, if a user adds their own reaction to the bot's loading message, the bot shouldn't remove it when loading is complete.

Therefore, this updates the cow emojis feature to only remove the bot's own reactions, which means it now no longer needs any sensitive privileges.