### PR TITLE
Removes extra YT URL parameters to prevent errors

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -83,6 +83,18 @@ export default class implements Command {
           // YouTube playlist
           newSongs.push(...await this.getSongs.youtubePlaylist(url.searchParams.get('list') as string));
         } else {
+          let extraParameters: string[] = [];
+
+          url.searchParams.forEach((value, name) => {
+            if (name !== 'v' && value) {
+              extraParameters.push(name);
+            }
+          });
+
+          extraParameters.forEach(p => {
+            url.searchParams.delete(p);
+          });
+
           // Single video
           const song = await this.getSongs.youtubeVideo(url.href);
 


### PR DESCRIPTION
I was getting "that doesn't exist" errors whenever using a link like this:

``` shell
-p https://www.youtube.com/watch?v=JLfPx63bYf8&ab_channel=CHILLAF
```

If I were to remove the extra parameters it works fine
``` shell
-p https://www.youtube.com/watch?v=JLfPx63bYf8
```

So I implemented this in the code, what do you think? Could there be any consequences or is this fine?