### PR TITLE
Fix URL cleaning

### DIFF
--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -9,6 +9,7 @@ import pLimit from 'p-limit';
 import shuffle from 'array-shuffle';
 import {QueuedSong, QueuedPlaylist} from '../services/player';
 import {TYPES} from '../types';
+import {cleanUrl} from '../utils/url';
 
 @injectable()
 export default class {
@@ -34,16 +35,7 @@ export default class {
 
   async youtubeVideo(url: string): Promise<QueuedSong|null> {
     try {
-      // Clean URL
-      const u = new URL(url);
-
-      for (const [name] of u.searchParams) {
-        if (name !== 'v') {
-          u.searchParams.delete(name);
-        }
-      }
-
-      const videoDetails = await this.youtube.videos.get(u.toString());
+      const videoDetails = await this.youtube.videos.get(cleanUrl(url));
 
       return {
         title: videoDetails.snippet.title,

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,18 @@
+import {URL} from 'url';
+
+export const cleanUrl = (url: string) => {
+  try {
+    // Clean URL
+    const u = new URL(url);
+
+    for (const [name] of u.searchParams) {
+      if (name !== 'v') {
+        u.searchParams.delete(name);
+      }
+    }
+    return u.toString();
+  }
+  catch (_: unknown) {
+    return url;
+  }
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -10,9 +10,9 @@ export const cleanUrl = (url: string) => {
         u.searchParams.delete(name);
       }
     }
+
     return u.toString();
-  }
-  catch (_: unknown) {
+  } catch (_: unknown) {
     return url;
   }
-}
+};


### PR DESCRIPTION
As youtube API returns video ids instead of URLs, i.e., `aMKHMcS7X3g`, doing `new URL('aMKHMcS7X3g')` throws an error.
This intends to fix that and make youtube search and spotify to youtube conversion work.