### PR TITLE
Fix song searching

### DIFF
--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -27,7 +27,7 @@ export default class {
     try {
       const {items: [video]} = await this.youtube.videos.search({q: query, maxResults: 1, type: 'video'});
 
-      return await this.youtubeVideo(video.id.videoId);
+      return await this.youtubeVideo(`https://www.youtube.com/watch?v=${video.id.videoId}`);
     } catch (_: unknown) {
       return null;
     }


### PR DESCRIPTION
Youtube queries currently all return "that doesn't exist" as `this,youtubeVideo()` expects a URL, not a video ID.