### PR TITLE
Stay after queue ends

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -9,6 +9,7 @@ export default class implements Command {
   public name = 'config';
   public aliases = [];
   public examples = [
+    ['config', 'see all available settings'],
     ['config prefix !', 'set the prefix to !'],
     ['config channel music-commands', 'bind the bot to the music-commands channel']
   ];

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -20,7 +20,8 @@ export default class implements Command {
 
       if (settings) {
         let response = `prefix: \`${settings.prefix}\`\n`;
-        response += `channel: ${msg.guild!.channels.cache.get(settings.channel)!.toString()}`;
+        response += `channel: ${msg.guild!.channels.cache.get(settings.channel)!.toString()}\n`;
+        response += `stayAfter: ${settings.stayAfterQueueEnds.toString()}`;
 
         await msg.channel.send(response);
       }
@@ -70,6 +71,15 @@ export default class implements Command {
           await msg.channel.send(errorMsg('either that channel doesn\'t exist or you want me to become sentient and listen to a voice channel'));
         }
 
+        break;
+      }
+
+      case 'stayAfter': {
+        const value = args[1] === '1' || args[1] === 'true';
+
+        await Settings.update({stayAfterQueueEnds: value}, {where: {guildId: msg.guild!.id}});
+
+        await msg.channel.send(`👍 stayAfter updated to \`${value.toString()}\``);
         break;
       }
 

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -83,6 +83,18 @@ export default class implements Command {
           // YouTube playlist
           newSongs.push(...await this.getSongs.youtubePlaylist(url.searchParams.get('list') as string));
         } else {
+          let extraParameters: string[] = [];
+
+          url.searchParams.forEach((value, name) => {
+            if (name !== 'v' && value) {
+              extraParameters.push(name);
+            }
+          });
+
+          extraParameters.forEach(p => {
+            url.searchParams.delete(p);
+          });
+
           // Single video
           const song = await this.getSongs.youtubeVideo(url.href);
 

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -83,18 +83,6 @@ export default class implements Command {
           // YouTube playlist
           newSongs.push(...await this.getSongs.youtubePlaylist(url.searchParams.get('list') as string));
         } else {
-          let extraParameters: string[] = [];
-
-          url.searchParams.forEach((value, name) => {
-            if (name !== 'v' && value) {
-              extraParameters.push(name);
-            }
-          });
-
-          extraParameters.forEach(p => {
-            url.searchParams.delete(p);
-          });
-
           // Single video
           const song = await this.getSongs.youtubeVideo(url.href);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const refreshSpotifyToken = async () => {
   await makeDir(container.get(TYPES.Config.CACHE_DIR));
   await makeDir(path.join(container.get(TYPES.Config.CACHE_DIR), 'tmp'));
 
-  await sequelize.sync({});
+  await sequelize.sync({alter: true});
 
   await bot.listen();
 })();

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -15,4 +15,8 @@ export default class Settings extends Model<Settings> {
   @Default(false)
   @Column
   finishedSetup!: boolean;
+
+  @Default(false)
+  @Column
+  stayAfterQueueEnds!: boolean;
 }

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -169,7 +169,12 @@ export default class {
         await this.play();
       } else {
         this.status = STATUS.PAUSED;
-        this.disconnect();
+
+        let settings = await Settings.findByPk(this.voiceConnection?.channel.guild.id);
+
+        if (!settings?.stayAfterQueueEnds) {
+          this.disconnect();
+        }
       }
     } catch (error: unknown) {
       this.queuePosition--;

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -1,4 +1,5 @@
 import {VoiceConnection, VoiceChannel, StreamDispatcher} from 'discord.js';
+import {Settings} from '../models';
 import {promises as fs, createWriteStream} from 'fs';
 import {Readable, PassThrough} from 'stream';
 import path from 'path';


### PR DESCRIPTION
On the servers I'm on more often than not the queue stays empty for a few seconds before someone realizes and adds a new song, with the default behavior you get an annoying amount of `leave`/`join` sound notifications.

So, I added a setting to control this behavior.

Open to suggestions in case you disagree with the approach :D