### PR TITLE
Play behavior fix

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -159,12 +159,16 @@ export default class implements Command {
       await res.stop(`u betcha, **${firstSong.title}** and ${newSongs.length - 1} other songs were added to the queue${extraMsg}`);
     }
 
+    if (player.voiceConnection === null) {
+      await player.connect(targetVoiceChannel);
+
+      if (player.status === STATUS.PAUSED && queueOldSize) {
+        await msg.channel.send('joined, but I\'m paused, use a lonely `-p` to resume playback');
+      }
+    }
+
     if (queueOldSize === 0 && !wasPlayingSong) {
       // Only auto-play if queue was empty before and nothing was playing
-      if (player.voiceConnection === null) {
-        await player.connect(targetVoiceChannel);
-      }
-
       await player.play();
     }
   }

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -83,6 +83,18 @@ export default class implements Command {
           // YouTube playlist
           newSongs.push(...await this.getSongs.youtubePlaylist(url.searchParams.get('list') as string));
         } else {
+          let extraParameters: string[] = [];
+
+          url.searchParams.forEach((value, name) => {
+            if (name !== 'v' && value) {
+              extraParameters.push(name);
+            }
+          });
+
+          extraParameters.forEach(p => {
+            url.searchParams.delete(p);
+          });
+
           // Single video
           const song = await this.getSongs.youtubeVideo(url.href);
 

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -83,18 +83,6 @@ export default class implements Command {
           // YouTube playlist
           newSongs.push(...await this.getSongs.youtubePlaylist(url.searchParams.get('list') as string));
         } else {
-          let extraParameters: string[] = [];
-
-          url.searchParams.forEach((value, name) => {
-            if (name !== 'v' && value) {
-              extraParameters.push(name);
-            }
-          });
-
-          extraParameters.forEach(p => {
-            url.searchParams.delete(p);
-          });
-
           // Single video
           const song = await this.getSongs.youtubeVideo(url.href);
 


### PR DESCRIPTION
I experienced what felt like a bug:

If the bot was in the middle of playing a song and everyone left, the next time you attempted to play anything after, it'd start playing but wouldn't come back to the voice channel.

The culprit was this code fragment, since it would still have songs in the player (`queueOldSize > 0`) and [got paused](https://github.com/codetheweb/muse/blob/master/src/services/player.ts#L56) when disconnecting it would only join again when you sent a `-p` without anything.

To make the experience smoother, I removed the `player.voiceConnection === null` from the conditional and added a message to explain it is paused.