### PR TITLE
Spotify token refresh fix

### DIFF
--- a/src/services/third-party.ts
+++ b/src/services/third-party.ts
@@ -33,6 +33,6 @@ export default class ThirdParty {
     const auth = await this.spotify.clientCredentialsGrant();
     this.spotify.setAccessToken(auth.body.access_token);
 
-    this.spotifyTokenTimerId = setTimeout(this.refreshSpotifyToken, (auth.body.expires_in / 2) * 1000);
+    this.spotifyTokenTimerId = setTimeout(this.refreshSpotifyToken.bind(this), (auth.body.expires_in / 2) * 1000);
   }
 }


### PR DESCRIPTION
Fixes codetheweb/muse#361 I submitted regarding the token not refreshing when its expired by binding the function when it is called recursively.