### PR TITLE
Add `split` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `/play` has a new `split` option that will split queued YouTube videos into chapters, if the video has them
 
 ## [1.2.0] - 2022-02-24
 ### Added

--- a/src/commands/favorites.ts
+++ b/src/commands/favorites.ts
@@ -24,7 +24,10 @@ export default class implements Command {
         .setDescription('add track to the front of the queue'))
       .addBooleanOption(option => option
         .setName('shuffle')
-        .setDescription('shuffle the input if you\'re adding multiple tracks')))
+        .setDescription('shuffle the input if you\'re adding multiple tracks'))
+      .addBooleanOption(option => option
+        .setName('split')
+        .setDescription('if a track has chapters, split it')))
     .addSubcommand(subcommand => subcommand
       .setName('list')
       .setDescription('list all favorites'))
@@ -116,6 +119,7 @@ export default class implements Command {
       query: favorite.query,
       shuffleAdditions: interaction.options.getBoolean('shuffle') ?? false,
       addToFrontOfQueue: interaction.options.getBoolean('immediate') ?? false,
+      splitChapters: interaction.options.getBoolean('split') ?? false,
     });
   }
 

--- a/src/commands/favorites.ts
+++ b/src/commands/favorites.ts
@@ -119,7 +119,7 @@ export default class implements Command {
       query: favorite.query,
       shuffleAdditions: interaction.options.getBoolean('shuffle') ?? false,
       addToFrontOfQueue: interaction.options.getBoolean('immediate') ?? false,
-      splitChapters: interaction.options.getBoolean('split') ?? false,
+      shouldSplitChapters: interaction.options.getBoolean('split') ?? false,
     });
   }
 

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -81,7 +81,7 @@ export default class implements Command {
       query: query.trim(),
       addToFrontOfQueue: interaction.options.getBoolean('immediate') ?? false,
       shuffleAdditions: interaction.options.getBoolean('shuffle') ?? false,
-      splitChapters: interaction.options.getBoolean('split') ?? false,
+      shouldSplitChapters: interaction.options.getBoolean('split') ?? false,
     });
   }
 

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -29,7 +29,10 @@ export default class implements Command {
       .setDescription('add track to the front of the queue'))
     .addBooleanOption(option => option
       .setName('shuffle')
-      .setDescription('shuffle the input if you\'re adding multiple tracks'));
+      .setDescription('shuffle the input if you\'re adding multiple tracks'))
+    .addBooleanOption(option => option
+      .setName('split')
+      .setDescription('if a track has chapters, split it'));
 
   public requiresVC = true;
 
@@ -78,6 +81,7 @@ export default class implements Command {
       query: query.trim(),
       addToFrontOfQueue: interaction.options.getBoolean('immediate') ?? false,
       shuffleAdditions: interaction.options.getBoolean('shuffle') ?? false,
+      splitChapters: interaction.options.getBoolean('split') ?? false,
     });
   }
 

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -25,7 +25,7 @@ export default class implements Command {
   }
 
   public async execute(interaction: CommandInteraction): Promise<void> {
-    const numToSkip = interaction.options.getInteger('skip') ?? 1;
+    const numToSkip = interaction.options.getInteger('number') ?? 1;
 
     if (numToSkip < 1) {
       throw new Error('invalid number of songs to skip');

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -19,13 +19,13 @@ export default class AddQueryToQueue {
     query,
     addToFrontOfQueue,
     shuffleAdditions,
-    splitChapters,
+    shouldSplitChapters,
     interaction,
   }: {
     query: string;
     addToFrontOfQueue: boolean;
     shuffleAdditions: boolean;
-    splitChapters: boolean;
+    shouldSplitChapters: boolean;
     interaction: CommandInteraction;
   }): Promise<void> {
     const guildId = interaction.guild!.id;
@@ -63,9 +63,9 @@ export default class AddQueryToQueue {
         // YouTube source
         if (url.searchParams.get('list')) {
           // YouTube playlist
-          newSongs.push(...await this.getSongs.youtubePlaylist(url.searchParams.get('list')!, splitChapters));
+          newSongs.push(...await this.getSongs.youtubePlaylist(url.searchParams.get('list')!, shouldSplitChapters));
         } else {
-          const songs = await this.getSongs.youtubeVideo(url.href, splitChapters);
+          const songs = await this.getSongs.youtubeVideo(url.href, shouldSplitChapters);
 
           if (songs) {
             newSongs.push(...songs);
@@ -74,7 +74,7 @@ export default class AddQueryToQueue {
           }
         }
       } else if (url.protocol === 'spotify:' || url.host === 'open.spotify.com') {
-        const [convertedSongs, nSongsNotFound, totalSongs] = await this.getSongs.spotifySource(query, playlistLimit, splitChapters);
+        const [convertedSongs, nSongsNotFound, totalSongs] = await this.getSongs.spotifySource(query, playlistLimit, shouldSplitChapters);
 
         if (totalSongs > playlistLimit) {
           extraMsg = `a random sample of ${playlistLimit} songs was taken`;
@@ -96,7 +96,7 @@ export default class AddQueryToQueue {
       }
     } catch (_: unknown) {
       // Not a URL, must search YouTube
-      const songs = await this.getSongs.youtubeVideoSearch(query, splitChapters);
+      const songs = await this.getSongs.youtubeVideoSearch(query, shouldSplitChapters);
 
       if (songs) {
         newSongs.push(...songs);

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -294,8 +294,6 @@ export default class {
       url = video.id;
     }
 
-    const chapters = this.parseChaptersFromDescription(video.snippet.description, videoDurationSeconds);
-
     const base: SongMetadata = {
       title: video.snippet.title,
       artist: video.snippet.channelTitle,
@@ -307,7 +305,13 @@ export default class {
       thumbnailUrl: video.snippet.thumbnails.medium.url,
     };
 
-    if (!chapters || !shouldSplitChapters) {
+    if (!shouldSplitChapters) {
+      return [base];
+    }
+
+    const chapters = this.parseChaptersFromDescription(video.snippet.description, videoDurationSeconds);
+
+    if (!chapters) {
       return [base];
     }
 

--- a/src/utils/build-embed.ts
+++ b/src/utils/build-embed.ts
@@ -13,13 +13,13 @@ const getMaxSongTitleLength = (title: string) => {
   return nonASCII.test(title) ? 28 : 48;
 };
 
-const getSongTitle = ({title, url}: QueuedSong, shouldTruncate = false) => {
+const getSongTitle = ({title, url, offset}: QueuedSong, shouldTruncate = false) => {
   const cleanSongTitle = title.replace(/\[.*\]/, '').trim();
 
   const songTitle = shouldTruncate ? truncate(cleanSongTitle, getMaxSongTitleLength(cleanSongTitle)) : cleanSongTitle;
   const youtubeId = url.length === 11 ? url : getYouTubeID(url) ?? '';
 
-  return `[${songTitle}](https://www.youtube.com/watch?v=${youtubeId})`;
+  return `[${songTitle}](https://www.youtube.com/watch?v=${youtubeId}${offset === 0 ? '' : '&t=' + String(offset)})`;
 };
 
 const getQueueInfo = (player: Player) => {


### PR DESCRIPTION
Add `split` command, to load each chapter of a YouTube video as a song in the queue.

I'm creating this as a draft to gather feedback, and also because I have to review the code and improve some things.

Example:
![Screenshot_15](https://user-images.githubusercontent.com/5438762/134829524-32e8956f-e812-4e78-846d-518f75241ba7.png)

One doubt that I have is about this piece of code:
https://github.com/codetheweb/muse/blob/dcac22832d02376c351603c944aabec17f2b7d1b/src/services/player.ts#L374-L377

I've removed the `+7`, because for me this was just skipping 7 seconds of the music.
I'm not sure if this should be removed though. If it's there, it's there for some reason, right?
I'm using the Windows version of FFmpeg.
