### PR TITLE
Fix whole playlist fails when one song is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Switched back to an Alpine container base image to reduce size
-- Unable to queue spotify playlist when a song is not available on Youtube search
+- Queueing Spotify playlists could sometimes fail when a song wasn't found on YouTube
 
 ## [0.5.0] - 2022-01-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Switched back to an Alpine container base image to reduce size
+- Unable to queue spotify playlist when a song is not available on Youtube search
 
 ## [0.5.0] - 2022-01-21
 ### Changed

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -17,7 +17,6 @@ import Config from './config.js';
 import KeyValueCacheProvider from './key-value-cache.js';
 
 type SongMetadata = Except<QueuedSong, 'addedInChannelId' | 'requestedBy'>;
-type SearchResult = SongMetadata | null;
 
 const ONE_HOUR_IN_SECONDS = 60 * 60;
 const ONE_MINUTE_IN_SECONDS = 1 * 60;
@@ -43,7 +42,7 @@ export default class {
     this.ytsrQueue = new PQueue({concurrency: 4});
   }
 
-  async youtubeVideoSearch(query: string): Promise<SearchResult> {
+  async youtubeVideoSearch(query: string): Promise<SongMetadata> {
     const {items} = await this.ytsrQueue.add(async () => this.cache.wrap(
       ytsr,
       query,
@@ -65,7 +64,7 @@ export default class {
     }
 
     if (!firstVideo) {
-      return null;
+      throw new Error('No video found.');
     }
 
     return this.youtubeVideo(firstVideo.id);
@@ -274,7 +273,7 @@ export default class {
     return [songs as SongMetadata[], nSongsNotFound, originalNSongs];
   }
 
-  private async spotifyToYouTube(track: SpotifyApi.TrackObjectSimplified, _: QueuedPlaylist | null): Promise<SearchResult> {
+  private async spotifyToYouTube(track: SpotifyApi.TrackObjectSimplified, _: QueuedPlaylist | null): Promise<SongMetadata> {
     return this.youtubeVideoSearch(`"${track.name}" "${track.artists[0].name}"`);
   }
 }

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -17,6 +17,7 @@ import Config from './config.js';
 import KeyValueCacheProvider from './key-value-cache.js';
 
 type SongMetadata = Except<QueuedSong, 'addedInChannelId' | 'requestedBy'>;
+type SearchResult = SongMetadata | null;
 
 const ONE_HOUR_IN_SECONDS = 60 * 60;
 const ONE_MINUTE_IN_SECONDS = 1 * 60;
@@ -42,7 +43,7 @@ export default class {
     this.ytsrQueue = new PQueue({concurrency: 4});
   }
 
-  async youtubeVideoSearch(query: string): Promise<SongMetadata> {
+  async youtubeVideoSearch(query: string): Promise<SearchResult> {
     const {items} = await this.ytsrQueue.add(async () => this.cache.wrap(
       ytsr,
       query,
@@ -64,7 +65,7 @@ export default class {
     }
 
     if (!firstVideo) {
-      throw new Error('No video found.');
+      return null;
     }
 
     return this.youtubeVideo(firstVideo.id);
@@ -273,7 +274,7 @@ export default class {
     return [songs as SongMetadata[], nSongsNotFound, originalNSongs];
   }
 
-  private async spotifyToYouTube(track: SpotifyApi.TrackObjectSimplified, _: QueuedPlaylist | null): Promise<SongMetadata> {
+  private async spotifyToYouTube(track: SpotifyApi.TrackObjectSimplified, _: QueuedPlaylist | null): Promise<SearchResult> {
     return this.youtubeVideoSearch(`"${track.name}" "${track.artists[0].name}"`);
   }
 }


### PR DESCRIPTION
Closes #487 

Fix whole playlist fails when one song is unavailable

Steps to reproduce the issue
1. Queue this playlist (https://open.spotify.com/playlist/7N1jyF6MDKPdYcRG2DT5aa?si=0d034d2cb4c8402f)
2. Bot respond with "no video found."

Note: This is a quick fix. I'm not sure what's the desired behavior - with this fix it would go back to the previous response of showing how many songs was not available and queue the available ones. I think it's reasonable that youtubeSearch() would return a song or null, however if there are any other errors which should be logged or handled differently then a different model that returns an error message would be required.

- [ ] I updated the changelog
