### PR TITLE
Add required dependency for node-gyp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Switched back to an Alpine container base image to reduce size
+- Add missing node-gyp dependencies
 
 ## [0.5.0] - 2022-01-21
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.13.2-alpine AS base
 
 # Install ffmpeg
 RUN apk update && \
-    apk add ffmpeg && \
+    apk add ffmpeg python3 make g++ && \
     rm -rf /var/cache/apk/* 
 
 WORKDIR /usr/app


### PR DESCRIPTION
Closes #490

Add node-gyp dependencies as indicated in the documentation (https://github.com/nodejs/node-gyp#on-unix)

- [x] I updated the changelog
