### PR TITLE
Configurable voice channel leave behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Muse now stays in a voice channel after the queue finishes for 30 seconds by default. This behavior can be changed with `/config set-wait-after-queue-empties`.
 
 ## [1.0.0] - 2022-02-05
 ### Changed

--- a/migrations/20220212014052_add_seconds_to_wait_after_queue_empties_and_leave_if_no_listeners/migration.sql
+++ b/migrations/20220212014052_add_seconds_to_wait_after_queue_empties_and_leave_if_no_listeners/migration.sql
@@ -1,0 +1,16 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Setting" (
+    "guildId" TEXT NOT NULL PRIMARY KEY,
+    "playlistLimit" INTEGER NOT NULL DEFAULT 50,
+    "secondsToWaitAfterQueueEmpties" INTEGER NOT NULL DEFAULT 30,
+    "leaveIfNoListeners" BOOLEAN NOT NULL DEFAULT true,
+    "roleId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Setting" ("createdAt", "guildId", "playlistLimit", "roleId", "updatedAt") SELECT "createdAt", "guildId", "playlistLimit", "roleId", "updatedAt" FROM "Setting";
+DROP TABLE "Setting";
+ALTER TABLE "new_Setting" RENAME TO "Setting";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,6 @@
 {
     "ignore": ["**/*.test.ts", "**/*.spec.ts", ".git", "node_modules"],
     "watch": ["dist"],
-    "exec": "npm run env:set-database-url -- node --experimental-json-modules dist/src/scripts/start.js",
+    "exec": "npm run env:set-database-url -- node --experimental-json-modules dist/scripts/start.js",
     "ext": "js"
 }

--- a/schema.prisma
+++ b/schema.prisma
@@ -24,11 +24,12 @@ model KeyValueCache {
 }
 
 model Setting {
-  guildId       String   @id
-  playlistLimit Int      @default(50)
-  roleId        String?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  guildId             String   @id
+  playlistLimit       Int      @default(50)
+  waitAfterQueueEmpty Int      @default(30)
+  roleId              String?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 }
 
 model FavoriteQuery {

--- a/schema.prisma
+++ b/schema.prisma
@@ -27,6 +27,7 @@ model Setting {
   guildId             String   @id
   playlistLimit       Int      @default(50)
   waitAfterQueueEmpty Int      @default(30)
+  leaveIfNoListeners  Boolean  @default(true)
   roleId              String?
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt

--- a/schema.prisma
+++ b/schema.prisma
@@ -24,13 +24,13 @@ model KeyValueCache {
 }
 
 model Setting {
-  guildId             String   @id
-  playlistLimit       Int      @default(50)
-  waitAfterQueueEmpty Int      @default(30)
-  leaveIfNoListeners  Boolean  @default(true)
-  roleId              String?
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  guildId                        String   @id
+  playlistLimit                  Int      @default(50)
+  secondsToWaitAfterQueueEmpties Int      @default(30)
+  leaveIfNoListeners             Boolean  @default(true)
+  roleId                         String?
+  createdAt                      DateTime @default(now())
+  updatedAt                      DateTime @updatedAt
 }
 
 model FavoriteQuery {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -25,6 +25,14 @@ export default class implements Command {
         .setDescription('allowed role')
         .setRequired(true)))
     .addSubcommand(subcommand => subcommand
+      .setName('set-wait-after-queue-empty')
+      .setDescription('set the time to wait before leaving the voice channel when queue empties')
+      .addIntegerOption(option => option
+        .setName('delay')
+        .setDescription('delay in seconds (set to 0 to never leave)')
+        .setRequired(true)
+        .setMinValue(0)))
+    .addSubcommand(subcommand => subcommand
       .setName('get')
       .setDescription('show all settings'));
 
@@ -70,6 +78,23 @@ export default class implements Command {
         break;
       }
 
+      case 'set-wait-after-queue-empty': {
+        const delay = interaction.options.getInteger('delay')!;
+
+        await prisma.setting.update({
+          where: {
+            guildId: interaction.guild!.id,
+          },
+          data: {
+            waitAfterQueueEmpty: delay,
+          },
+        });
+
+        await interaction.reply('👍 wait delay updated');
+
+        break;
+      }
+
       case 'get': {
         const embed = new MessageEmbed().setTitle('Config');
 
@@ -82,6 +107,7 @@ export default class implements Command {
         const settingsToShow = {
           'Playlist Limit': config.playlistLimit,
           Role: config.roleId ? `<@&${config.roleId}>` : 'not set',
+          'Wait before leaving after queue empty': `${config.waitAfterQueueEmpty}s`,
         };
 
         let description = '';

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -25,7 +25,7 @@ export default class implements Command {
         .setDescription('allowed role')
         .setRequired(true)))
     .addSubcommand(subcommand => subcommand
-      .setName('set-wait-after-queue-empty')
+      .setName('set-wait-after-queue-empties')
       .setDescription('set the time to wait before leaving the voice channel when queue empties')
       .addIntegerOption(option => option
         .setName('delay')
@@ -93,7 +93,7 @@ export default class implements Command {
             guildId: interaction.guild!.id,
           },
           data: {
-            waitAfterQueueEmpty: delay,
+            secondsToWaitAfterQueueEmpties: delay,
           },
         });
 
@@ -131,9 +131,9 @@ export default class implements Command {
         const settingsToShow = {
           'Playlist Limit': config.playlistLimit,
           Role: config.roleId ? `<@&${config.roleId}>` : 'not set',
-          'Wait before leaving after queue empty': config.waitAfterQueueEmpty === 0
+          'Wait before leaving after queue empty': config.secondsToWaitAfterQueueEmpties === 0
             ? 'never leave'
-            : `${config.waitAfterQueueEmpty}s`,
+            : `${config.secondsToWaitAfterQueueEmpties}s`,
           'Leave if there are no listeners': config.leaveIfNoListeners ? 'yes' : 'no',
         };
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -33,6 +33,13 @@ export default class implements Command {
         .setRequired(true)
         .setMinValue(0)))
     .addSubcommand(subcommand => subcommand
+      .setName('set-leave-if-no-listeners')
+      .setDescription('set whether to leave when all other participants leave')
+      .addBooleanOption(option => option
+        .setName('value')
+        .setDescription('whether to leave when everyone else leaves')
+        .setRequired(true)))
+    .addSubcommand(subcommand => subcommand
       .setName('get')
       .setDescription('show all settings'));
 
@@ -95,6 +102,23 @@ export default class implements Command {
         break;
       }
 
+      case 'set-leave-if-no-listeners': {
+        const value = interaction.options.getBoolean('value')!;
+
+        await prisma.setting.update({
+          where: {
+            guildId: interaction.guild!.id,
+          },
+          data: {
+            leaveIfNoListeners: value,
+          },
+        });
+
+        await interaction.reply('👍 leave setting updated');
+
+        break;
+      }
+
       case 'get': {
         const embed = new MessageEmbed().setTitle('Config');
 
@@ -108,6 +132,7 @@ export default class implements Command {
           'Playlist Limit': config.playlistLimit,
           Role: config.roleId ? `<@&${config.roleId}>` : 'not set',
           'Wait before leaving after queue empty': `${config.waitAfterQueueEmpty}s`,
+          'Leave if there are no listeners': config.leaveIfNoListeners ? 'yes' : 'no',
         };
 
         let description = '';

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -131,7 +131,9 @@ export default class implements Command {
         const settingsToShow = {
           'Playlist Limit': config.playlistLimit,
           Role: config.roleId ? `<@&${config.roleId}>` : 'not set',
-          'Wait before leaving after queue empty': `${config.waitAfterQueueEmpty}s`,
+          'Wait before leaving after queue empty': config.waitAfterQueueEmpty === 0
+            ? 'never leave'
+            : `${config.waitAfterQueueEmpty}s`,
           'Leave if there are no listeners': config.leaveIfNoListeners ? 'yes' : 'no',
         };
 

--- a/src/events/voice-state-update.ts
+++ b/src/events/voice-state-update.ts
@@ -3,7 +3,7 @@ import container from '../inversify.config.js';
 import {TYPES} from '../types.js';
 import PlayerManager from '../managers/player.js';
 import {getSizeWithoutBots} from '../utils/channels.js';
-import { prisma } from '../utils/db.js';
+import {prisma} from '../utils/db.js';
 
 export default async (oldState: VoiceState, _: VoiceState): Promise<void> => {
   const playerManager = container.get<PlayerManager>(TYPES.Managers.Player);
@@ -12,13 +12,13 @@ export default async (oldState: VoiceState, _: VoiceState): Promise<void> => {
 
   if (player.voiceConnection) {
     const voiceChannel: VoiceChannel = oldState.guild.channels.cache.get(player.voiceConnection.joinConfig.channelId!) as VoiceChannel;
-    const settings = await prisma.setting.findUnique({where: { guildId: player.guildId }});
+    const settings = await prisma.setting.findUnique({where: {guildId: player.guildId}});
 
     if (!settings) {
       throw new Error('Could not find settings for guild');
     }
 
-    const { leaveIfNoListeners } = settings;
+    const {leaveIfNoListeners} = settings;
     if (!voiceChannel || (getSizeWithoutBots(voiceChannel) === 0 && leaveIfNoListeners)) {
       player.disconnect();
     }

--- a/src/events/voice-state-update.ts
+++ b/src/events/voice-state-update.ts
@@ -3,15 +3,23 @@ import container from '../inversify.config.js';
 import {TYPES} from '../types.js';
 import PlayerManager from '../managers/player.js';
 import {getSizeWithoutBots} from '../utils/channels.js';
+import { prisma } from '../utils/db.js';
 
-export default (oldState: VoiceState, _: VoiceState): void => {
+export default async (oldState: VoiceState, _: VoiceState): Promise<void> => {
   const playerManager = container.get<PlayerManager>(TYPES.Managers.Player);
 
   const player = playerManager.get(oldState.guild.id);
 
   if (player.voiceConnection) {
     const voiceChannel: VoiceChannel = oldState.guild.channels.cache.get(player.voiceConnection.joinConfig.channelId!) as VoiceChannel;
-    if (!voiceChannel || getSizeWithoutBots(voiceChannel) === 0) {
+    const settings = await prisma.setting.findUnique({where: { guildId: player.guildId }});
+
+    if (!settings) {
+      throw new Error('Could not find settings for guild');
+    }
+
+    const { leaveIfNoListeners } = settings;
+    if (!voiceChannel || (getSizeWithoutBots(voiceChannel) === 0 && leaveIfNoListeners)) {
       player.disconnect();
     }
   }

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -4,7 +4,7 @@ import {Except} from 'type-fest';
 import shuffle from 'array-shuffle';
 import {TYPES} from '../types.js';
 import GetSongs from '../services/get-songs.js';
-import {QueuedSong} from './player.js';
+import {QueuedSong, STATUS} from './player.js';
 import PlayerManager from '../managers/player.js';
 import {prisma} from '../utils/db.js';
 import {buildPlayingMessageEmbed} from '../utils/build-embed.js';
@@ -131,6 +131,9 @@ export default class AddQueryToQueue {
       await interaction.editReply({
         embeds: [buildPlayingMessageEmbed(player)],
       });
+    } else if (player.status === STATUS.IDLE) {
+      // player is idle, start playback instead
+      await player.play();
     }
 
     // Build response message

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -132,7 +132,7 @@ export default class AddQueryToQueue {
         embeds: [buildPlayingMessageEmbed(player)],
       });
     } else if (player.status === STATUS.IDLE) {
-      // player is idle, start playback instead
+      // Player is idle, start playback instead
       await player.play();
     }
 

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -8,6 +8,7 @@ import shuffle from 'array-shuffle';
 import {AudioPlayer, AudioPlayerStatus, createAudioPlayer, createAudioResource, joinVoiceChannel, StreamType, VoiceConnection, VoiceConnectionStatus} from '@discordjs/voice';
 import FileCacheProvider from './file-cache.js';
 import debug from '../utils/debug.js';
+import { prisma } from '../utils/db.js';
 
 export interface QueuedPlaylist {
   title: string;
@@ -29,6 +30,7 @@ export interface QueuedSong {
 export enum STATUS {
   PLAYING,
   PAUSED,
+  IDLE,
 }
 
 export interface PlayerEvents {
@@ -50,6 +52,7 @@ export default class {
   private positionInSeconds = 0;
 
   private readonly fileCache: FileCacheProvider;
+  private disconnectTimer: NodeJS.Timeout | null = null;
 
   constructor(fileCache: FileCacheProvider, guildId: string) {
     this.fileCache = fileCache;
@@ -131,6 +134,12 @@ export default class {
       throw new Error('Queue empty.');
     }
 
+    // cancel any pending idle disconnection
+    if (this.disconnectTimer) {
+      clearInterval(this.disconnectTimer)
+      this.disconnectTimer = null;
+    }
+
     // Resume from paused state
     if (this.status === STATUS.PAUSED && currentSong.url === this.nowPlaying?.url) {
       if (this.audioPlayer) {
@@ -210,8 +219,24 @@ export default class {
       if (this.getCurrent() && this.status !== STATUS.PAUSED) {
         await this.play();
       } else {
-        this.status = STATUS.PAUSED;
-        this.disconnect();
+        this.status = STATUS.IDLE;
+
+        const settings = await prisma.setting.findUnique({where: { guildId: this.guildId }});
+
+        if (!settings) {
+          throw new Error('Could not find settings for guild');
+        }
+
+        const { waitAfterQueueEmpty } = settings;
+        if (waitAfterQueueEmpty !== 0) {
+          this.disconnectTimer = setTimeout(() => {
+            // make sure we are not accidentally playing
+            // when disconnecting
+            if (this.status === STATUS.IDLE) {
+              this.disconnect();
+            }
+          }, waitAfterQueueEmpty * 1000)
+        }
       }
     } catch (error: unknown) {
       this.queuePosition--;


### PR DESCRIPTION
Adds two features mentioned in #513 and #481:
- configurable idle waiting time before leaving when queue empties (or don't leave at all)
- setting that allows you to *not* leave the VC when everyone else leaves.

Not sure about the descriptions and approach and stuff so always open to suggestions :D

Also, the default idling time before auto-disconnecting is now 30s, and the previous insta-leave is impossible (since 0 seconds disables the autoleave completely, though setting something like 1s gives mostly the same behavior)