### PR TITLE
Create `/resume` command; make `query` required for the `/play` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `/resume` command to resume playback
+
+### Changed
+- `query` is now a required parameter from `/play`
+
+### Removed
+- `/play` cannot resume the playback anymore since `query` is now required
 
 ## [1.2.0] - 2022-02-24
 ### Added

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -1,0 +1,46 @@
+import {SlashCommandBuilder} from '@discordjs/builders';
+import {inject, injectable} from 'inversify';
+import Command from '.';
+import {TYPES} from '../types.js';
+import PlayerManager from '../managers/player.js';
+import {STATUS} from '../services/player.js';
+import {buildPlayingMessageEmbed} from '../utils/build-embed.js';
+import {getMemberVoiceChannel, getMostPopularVoiceChannel} from '../utils/channels.js';
+import {CommandInteraction, GuildMember} from 'discord.js';
+
+@injectable()
+export default class implements Command {
+  public readonly slashCommand = new SlashCommandBuilder()
+    .setName('resume')
+    .setDescription('resume playback');
+
+  public requiresVC = true;
+
+  private readonly playerManager: PlayerManager;
+
+  constructor(@inject(TYPES.Managers.Player) playerManager: PlayerManager) {
+    this.playerManager = playerManager;
+  }
+
+  // eslint-disable-next-line complexity
+  public async execute(interaction: CommandInteraction): Promise<void> {
+    const player = this.playerManager.get(interaction.guild!.id);
+    const [targetVoiceChannel] = getMemberVoiceChannel(interaction.member as GuildMember) ?? getMostPopularVoiceChannel(interaction.guild!);
+    if (player.status === STATUS.PLAYING) {
+      throw new Error('already playing, give me a song name');
+    }
+
+    // Must be resuming play
+    if (!player.getCurrent()) {
+      throw new Error('nothing to play');
+    }
+
+    await player.connect(targetVoiceChannel);
+    await player.play();
+
+    await interaction.reply({
+      content: 'the stop-and-go light is now green',
+      embeds: [buildPlayingMessageEmbed(player)],
+    });
+  }
+}

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -23,6 +23,7 @@ import Pause from './commands/pause.js';
 import Play from './commands/play.js';
 import QueueCommand from './commands/queue.js';
 import Remove from './commands/remove.js';
+import Resume from './commands/resume.js';
 import Seek from './commands/seek.js';
 import Shuffle from './commands/shuffle.js';
 import Skip from './commands/skip.js';
@@ -64,6 +65,7 @@ container.bind<AddQueryToQueue>(TYPES.Services.AddQueryToQueue).to(AddQueryToQue
   Play,
   QueueCommand,
   Remove,
+  Resume,
   Seek,
   Shuffle,
   Skip,


### PR DESCRIPTION
Closes #537

Changed `/play` command: `query` parameter is now marked as required, removing the need to select the parameter to search/add a song.
Added `/resume` to resume playback, since this functionality is not possible anymore with the `/play` command alone.

- [x] I updated the changelog
