### PR TITLE
Support for web streaming audio files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Muse can now HTTP stream live audio files (see #396)
 
 ## [1.3.0] - 2022-03-09
 ### Added

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -11,6 +11,8 @@ import PlayerManager from './managers/player.js';
 // Services
 import AddQueryToQueue from './services/add-query-to-queue.js';
 import GetSongs from './services/get-songs.js';
+import YoutubeAPI from './services/youtube-api.js';
+import SpotifyAPI from './services/spotify-api.js';
 
 // Comands
 import Command from './commands';
@@ -53,6 +55,8 @@ container.bind<PlayerManager>(TYPES.Managers.Player).to(PlayerManager).inSinglet
 // Services
 container.bind<GetSongs>(TYPES.Services.GetSongs).to(GetSongs).inSingletonScope();
 container.bind<AddQueryToQueue>(TYPES.Services.AddQueryToQueue).to(AddQueryToQueue).inSingletonScope();
+container.bind<YoutubeAPI>(TYPES.Services.YoutubeAPI).to(YoutubeAPI).inSingletonScope();
+container.bind<SpotifyAPI>(TYPES.Services.SpotifyAPI).to(SpotifyAPI).inSingletonScope();
 
 // Commands
 [

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -93,6 +93,14 @@ export default class AddQueryToQueue {
         }
 
         newSongs.push(...convertedSongs);
+      } else {
+        const song = await this.getSongs.httpLiveStream(query);
+
+        if (song) {
+          newSongs.push(song);
+        } else {
+          throw new Error('that doesn\'t exist');
+        }
       }
     } catch (_: unknown) {
       // Not a URL, must search YouTube

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -1,11 +1,10 @@
 /* eslint-disable complexity */
 import {CommandInteraction, GuildMember} from 'discord.js';
 import {inject, injectable} from 'inversify';
-import {Except} from 'type-fest';
 import shuffle from 'array-shuffle';
 import {TYPES} from '../types.js';
 import GetSongs from '../services/get-songs.js';
-import {QueuedSong, STATUS} from './player.js';
+import {SongMetadata, STATUS} from './player.js';
 import PlayerManager from '../managers/player.js';
 import {prisma} from '../utils/db.js';
 import {buildPlayingMessageEmbed} from '../utils/build-embed.js';
@@ -44,7 +43,7 @@ export default class AddQueryToQueue {
 
     await interaction.deferReply();
 
-    let newSongs: Array<Except<QueuedSong, 'addedInChannelId' | 'requestedBy'>> = [];
+    let newSongs: SongMetadata[] = [];
     let extraMsg = '';
 
     // Test if it's a complete URL

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -1,268 +1,66 @@
-import {URL} from 'url';
 import {inject, injectable} from 'inversify';
-import {toSeconds, parse} from 'iso8601-duration';
-import got from 'got';
-import ytsr, {Video} from 'ytsr';
 import spotifyURI from 'spotify-uri';
-import Spotify from 'spotify-web-api-node';
-import YouTube, {YoutubePlaylistItem, YoutubeVideo} from 'youtube.ts';
-import PQueue from 'p-queue';
-import shuffle from 'array-shuffle';
 import {Except} from 'type-fest';
 import {QueuedSong, QueuedPlaylist, MediaSource} from '../services/player.js';
 import {TYPES} from '../types.js';
-import {cleanUrl} from '../utils/url.js';
-import ThirdParty from './third-party.js';
-import Config from './config.js';
-import KeyValueCacheProvider from './key-value-cache.js';
-import {ONE_HOUR_IN_SECONDS, ONE_MINUTE_IN_SECONDS} from '../utils/constants.js';
-import {parseTime} from '../utils/time.js';
 import ffmpeg from 'fluent-ffmpeg';
+import YoutubeAPI from './youtube-api.js';
+import SpotifyAPI, {SpotifyTrack} from './spotify-api.js';
 
 type SongMetadata = Except<QueuedSong, 'addedInChannelId' | 'requestedBy'>;
 
-interface VideoDetailsResponse {
-  id: string;
-  contentDetails: {
-    videoId: string;
-    duration: string;
-  };
-}
-
 @injectable()
 export default class {
-  private readonly youtube: YouTube;
-  private readonly youtubeKey: string;
-  private readonly spotify: Spotify;
-  private readonly cache: KeyValueCacheProvider;
-
-  private readonly ytsrQueue: PQueue;
+  private readonly youtubeAPI: YoutubeAPI;
+  private readonly spotifyAPI: SpotifyAPI;
 
   constructor(
-  @inject(TYPES.ThirdParty) thirdParty: ThirdParty,
-    @inject(TYPES.Config) config: Config,
-    @inject(TYPES.KeyValueCache) cache: KeyValueCacheProvider) {
-    this.youtube = thirdParty.youtube;
-    this.youtubeKey = config.YOUTUBE_API_KEY;
-    this.spotify = thirdParty.spotify;
-    this.cache = cache;
-
-    this.ytsrQueue = new PQueue({concurrency: 4});
+  @inject(TYPES.Services.YoutubeAPI) youtubeAPI: YoutubeAPI,
+    @inject(TYPES.Services.SpotifyAPI) spotifyAPI: SpotifyAPI) {
+    this.youtubeAPI = youtubeAPI;
+    this.spotifyAPI = spotifyAPI;
   }
 
   async youtubeVideoSearch(query: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
-    const {items} = await this.ytsrQueue.add(async () => this.cache.wrap(
-      ytsr,
-      query,
-      {
-        limit: 10,
-      },
-      {
-        expiresIn: ONE_HOUR_IN_SECONDS,
-      },
-    ));
-
-    let firstVideo: Video | undefined;
-
-    for (const item of items) {
-      if (item.type === 'video') {
-        firstVideo = item;
-        break;
-      }
-    }
-
-    if (!firstVideo) {
-      throw new Error('No video found.');
-    }
-
-    return this.youtubeVideo(firstVideo.id, shouldSplitChapters);
+    return this.youtubeAPI.search(query, shouldSplitChapters);
   }
 
   async youtubeVideo(url: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
-    const video = await this.cache.wrap(
-      this.youtube.videos.get,
-      cleanUrl(url),
-      {
-        expiresIn: ONE_HOUR_IN_SECONDS,
-      },
-    );
-
-    return this.getMetadataFromVideo({video, shouldSplitChapters});
+    return this.youtubeAPI.getVideo(url, shouldSplitChapters);
   }
 
   async youtubePlaylist(listId: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
-    // YouTube playlist
-    const playlist = await this.cache.wrap(
-      this.youtube.playlists.get,
-      listId,
-      {
-        expiresIn: ONE_MINUTE_IN_SECONDS,
-      },
-    );
-
-    const playlistVideos: YoutubePlaylistItem[] = [];
-    const videoDetailsPromises: Array<Promise<void>> = [];
-    const videoDetails: VideoDetailsResponse[] = [];
-
-    let nextToken: string | undefined;
-
-    while (playlistVideos.length !== playlist.contentDetails.itemCount) {
-      // eslint-disable-next-line no-await-in-loop
-      const {items, nextPageToken} = await this.cache.wrap(
-        this.youtube.playlists.items,
-        listId,
-        {maxResults: '50', pageToken: nextToken},
-        {
-          expiresIn: ONE_MINUTE_IN_SECONDS,
-        },
-      );
-
-      nextToken = nextPageToken;
-
-      playlistVideos.push(...items);
-
-      // Start fetching extra details about videos
-      videoDetailsPromises.push((async () => {
-        // Unfortunately, package doesn't provide a method for this
-        const p = {
-          searchParams: {
-            part: 'contentDetails',
-            id: items.map(item => item.contentDetails.videoId).join(','),
-            key: this.youtubeKey,
-            responseType: 'json',
-          },
-        };
-        const {items: videoDetailItems} = await this.cache.wrap(
-          async () => got(
-            'https://www.googleapis.com/youtube/v3/videos',
-            p,
-          ).json() as Promise<{items: VideoDetailsResponse[]}>,
-          p,
-          {
-            expiresIn: ONE_MINUTE_IN_SECONDS,
-          },
-        );
-
-        videoDetails.push(...videoDetailItems);
-      })());
-    }
-
-    await Promise.all(videoDetailsPromises);
-
-    const queuedPlaylist = {title: playlist.snippet.title, source: playlist.id};
-
-    const songsToReturn: SongMetadata[] = [];
-
-    for (const video of playlistVideos) {
-      try {
-        songsToReturn.push(...this.getMetadataFromVideo({
-          video,
-          queuedPlaylist,
-          videoDetails: videoDetails.find((i: {id: string}) => i.id === video.contentDetails.videoId),
-          shouldSplitChapters,
-        }));
-      } catch (_: unknown) {
-        // Private and deleted videos are sometimes in playlists, duration of these is not returned and they should not be added to the queue.
-      }
-    }
-
-    return songsToReturn;
+    return this.youtubeAPI.getPlaylist(listId, shouldSplitChapters);
   }
 
   async spotifySource(url: string, playlistLimit: number, shouldSplitChapters: boolean): Promise<[SongMetadata[], number, number]> {
     const parsed = spotifyURI.parse(url);
 
-    let tracks: SpotifyApi.TrackObjectSimplified[] = [];
-
-    let playlist: QueuedPlaylist | null = null;
-
     switch (parsed.type) {
       case 'album': {
-        const uri = parsed as spotifyURI.Album;
-
-        const [{body: album}, {body: {items}}] = await Promise.all([this.spotify.getAlbum(uri.id), this.spotify.getAlbumTracks(uri.id, {limit: 50})]);
-
-        tracks.push(...items);
-
-        playlist = {title: album.name, source: album.href};
-        break;
+        const [tracks, playlist] = await this.spotifyAPI.getAlbum(url, playlistLimit);
+        return this.spotifyToYouTube(tracks, shouldSplitChapters, playlist);
       }
 
       case 'playlist': {
-        const uri = parsed as spotifyURI.Playlist;
-
-        let [{body: playlistResponse}, {body: tracksResponse}] = await Promise.all([this.spotify.getPlaylist(uri.id), this.spotify.getPlaylistTracks(uri.id, {limit: 50})]);
-
-        playlist = {title: playlistResponse.name, source: playlistResponse.href};
-
-        tracks.push(...tracksResponse.items.map(playlistItem => playlistItem.track));
-
-        while (tracksResponse.next) {
-          // eslint-disable-next-line no-await-in-loop
-          ({body: tracksResponse} = await this.spotify.getPlaylistTracks(uri.id, {
-            limit: parseInt(new URL(tracksResponse.next).searchParams.get('limit') ?? '50', 10),
-            offset: parseInt(new URL(tracksResponse.next).searchParams.get('offset') ?? '0', 10),
-          }));
-
-          tracks.push(...tracksResponse.items.map(playlistItem => playlistItem.track));
-        }
-
-        break;
+        const [tracks, playlist] = await this.spotifyAPI.getPlaylist(url, playlistLimit);
+        return this.spotifyToYouTube(tracks, shouldSplitChapters, playlist);
       }
 
       case 'track': {
-        const uri = parsed as spotifyURI.Track;
-
-        const {body} = await this.spotify.getTrack(uri.id);
-
-        tracks.push(body);
-        break;
+        const tracks = [await this.spotifyAPI.getTrack(url)];
+        return this.spotifyToYouTube(tracks, shouldSplitChapters);
       }
 
       case 'artist': {
-        const uri = parsed as spotifyURI.Artist;
-
-        const {body} = await this.spotify.getArtistTopTracks(uri.id, 'US');
-
-        tracks.push(...body.tracks);
-        break;
+        const tracks = await this.spotifyAPI.getArtist(url, playlistLimit);
+        return this.spotifyToYouTube(tracks, shouldSplitChapters);
       }
 
       default: {
         return [[], 0, 0];
       }
     }
-
-    // Get random songs if the playlist is larger than limit
-    const originalNSongs = tracks.length;
-
-    if (tracks.length > playlistLimit) {
-      const shuffled = shuffle(tracks);
-
-      tracks = shuffled.slice(0, playlistLimit);
-    }
-
-    const searchResults = await Promise.allSettled(tracks.map(async track => this.spotifyToYouTube(track, shouldSplitChapters)));
-
-    let nSongsNotFound = 0;
-
-    // Count songs that couldn't be found
-    const songs: SongMetadata[] = searchResults.reduce((accum: SongMetadata[], result) => {
-      if (result.status === 'fulfilled') {
-        for (const v of result.value) {
-          accum.push({
-            ...v,
-            ...(playlist ? {playlist} : {}),
-          });
-        }
-      } else {
-        nSongsNotFound++;
-      }
-
-      return accum;
-    }, []);
-
-    return [songs, nSongsNotFound, originalNSongs];
   }
 
   async httpLiveStream(url: string): Promise<SongMetadata> {
@@ -287,111 +85,28 @@ export default class {
     });
   }
 
-  private async spotifyToYouTube(track: SpotifyApi.TrackObjectSimplified, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
-    return this.youtubeVideoSearch(`"${track.name}" "${track.artists[0].name}"`, shouldSplitChapters);
-  }
+  private async spotifyToYouTube(tracks: SpotifyTrack[], shouldSplitChapters: boolean, playlist?: QueuedPlaylist | undefined): Promise<[SongMetadata[], number, number]> {
+    const promisedResults = tracks.map(async track => this.youtubeAPI.search(`"${track.name}" "${track.artist}"`, shouldSplitChapters));
+    const searchResults = await Promise.allSettled(promisedResults);
 
-  // TODO: we should convert YouTube videos (from both single videos and playlists) to an intermediate representation so we don't have to check if it's from a playlist
-  private getMetadataFromVideo({
-    video,
-    queuedPlaylist,
-    videoDetails,
-    shouldSplitChapters,
-  }: {
-    video: YoutubeVideo | YoutubePlaylistItem;
-    queuedPlaylist?: QueuedPlaylist;
-    videoDetails?: VideoDetailsResponse;
-    shouldSplitChapters?: boolean;
-  }): SongMetadata[] {
-    let url: string;
-    let videoDurationSeconds: number;
-    // Dirty hack
-    if (queuedPlaylist) {
-      // Is playlist item
-      video = video as YoutubePlaylistItem;
-      url = video.contentDetails.videoId;
-      videoDurationSeconds = toSeconds(parse(videoDetails!.contentDetails.duration));
-    } else {
-      video = video as YoutubeVideo;
-      videoDurationSeconds = toSeconds(parse(video.contentDetails.duration));
-      url = video.id;
-    }
+    let nSongsNotFound = 0;
 
-    const base: SongMetadata = {
-      source: MediaSource.Youtube,
-      title: video.snippet.title,
-      artist: video.snippet.channelTitle,
-      length: videoDurationSeconds,
-      offset: 0,
-      url,
-      playlist: queuedPlaylist ?? null,
-      isLive: false,
-      thumbnailUrl: video.snippet.thumbnails.medium.url,
-    };
-
-    if (!shouldSplitChapters) {
-      return [base];
-    }
-
-    const chapters = this.parseChaptersFromDescription(video.snippet.description, videoDurationSeconds);
-
-    if (!chapters) {
-      return [base];
-    }
-
-    const tracks: SongMetadata[] = [];
-
-    for (const [label, {offset, length}] of chapters) {
-      tracks.push({
-        ...base,
-        offset,
-        length,
-        title: `${label} (${base.title})`,
-      });
-    }
-
-    return tracks;
-  }
-
-  private parseChaptersFromDescription(description: string, videoDurationSeconds: number) {
-    const map = new Map<string, {offset: number; length: number}>();
-    let foundFirstTimestamp = false;
-
-    const foundTimestamps: Array<{name: string; offset: number}> = [];
-    for (const line of description.split('\n')) {
-      const timestamps = Array.from(line.matchAll(/(?:\d+:)+\d+/g));
-      if (timestamps?.length !== 1) {
-        continue;
-      }
-
-      if (!foundFirstTimestamp) {
-        if (/0{1,2}:00/.test(timestamps[0][0])) {
-          foundFirstTimestamp = true;
-        } else {
-          continue;
+    // Count songs that couldn't be found
+    const songs: SongMetadata[] = searchResults.reduce((accum: SongMetadata[], result) => {
+      if (result.status === 'fulfilled') {
+        for (const v of result.value) {
+          accum.push({
+            ...v,
+            ...(playlist ? {playlist} : {}),
+          });
         }
+      } else {
+        nSongsNotFound++;
       }
 
-      const timestamp = timestamps[0][0];
-      const seconds = parseTime(timestamp);
-      const chapterName = line.split(timestamp)[1].trim();
+      return accum;
+    }, []);
 
-      foundTimestamps.push({name: chapterName, offset: seconds});
-    }
-
-    for (const [i, {name, offset}] of foundTimestamps.entries()) {
-      map.set(name, {
-        offset,
-        length: i === foundTimestamps.length - 1
-          ? videoDurationSeconds - offset
-          : foundTimestamps[i + 1].offset - offset,
-      });
-    }
-
-    if (!map.size) {
-      return null;
-    }
-
-    return map;
+    return [songs, nSongsNotFound, tracks.length];
   }
 }

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -1,13 +1,10 @@
 import {inject, injectable} from 'inversify';
 import spotifyURI from 'spotify-uri';
-import {Except} from 'type-fest';
-import {QueuedSong, QueuedPlaylist, MediaSource} from '../services/player.js';
+import {SongMetadata, QueuedPlaylist, MediaSource} from '../services/player.js';
 import {TYPES} from '../types.js';
 import ffmpeg from 'fluent-ffmpeg';
 import YoutubeAPI from './youtube-api.js';
 import SpotifyAPI, {SpotifyTrack} from './spotify-api.js';
-
-type SongMetadata = Except<QueuedSong, 'addedInChannelId' | 'requestedBy'>;
 
 @injectable()
 export default class {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -20,7 +20,7 @@ export interface QueuedPlaylist {
   source: string;
 }
 
-export interface QueuedSong {
+export interface SongMetadata {
   title: string;
   artist: string;
   url: string;
@@ -28,10 +28,12 @@ export interface QueuedSong {
   offset: number;
   playlist: QueuedPlaylist | null;
   isLive: boolean;
-  addedInChannelId: Snowflake;
   thumbnailUrl: string | null;
-  requestedBy: string;
   source: MediaSource;
+}
+export interface QueuedSong extends SongMetadata {
+  addedInChannelId: Snowflake;
+  requestedBy: string;
 }
 
 export enum STATUS {

--- a/src/services/spotify-api.ts
+++ b/src/services/spotify-api.ts
@@ -1,0 +1,79 @@
+import {URL} from 'url';
+import {inject, injectable} from 'inversify';
+import spotifyURI from 'spotify-uri';
+import Spotify from 'spotify-web-api-node';
+import {TYPES} from '../types.js';
+import ThirdParty from './third-party.js';
+import shuffle from 'array-shuffle';
+import {QueuedPlaylist} from './player.js';
+
+export interface SpotifyTrack {
+  name: string;
+  artist: string;
+}
+
+@injectable()
+export default class {
+  private readonly spotify: Spotify;
+
+  constructor(@inject(TYPES.ThirdParty) thirdParty: ThirdParty) {
+    this.spotify = thirdParty.spotify;
+  }
+
+  async getAlbum(url: string, playlistLimit: number): Promise<[SpotifyTrack[], QueuedPlaylist]> {
+    const uri = spotifyURI.parse(url) as spotifyURI.Album;
+    const [{body: album}, {body: {items}}] = await Promise.all([this.spotify.getAlbum(uri.id), this.spotify.getAlbumTracks(uri.id, {limit: 50})]);
+    const tracks = this.limitTracks(items, playlistLimit).map(this.toSpotifyTrack);
+    const playlist = {title: album.name, source: album.href};
+
+    return [tracks, playlist];
+  }
+
+  async getPlaylist(url: string, playlistLimit: number): Promise<[SpotifyTrack[], QueuedPlaylist]> {
+    const uri = spotifyURI.parse(url) as spotifyURI.Playlist;
+
+    let [{body: playlistResponse}, {body: tracksResponse}] = await Promise.all([this.spotify.getPlaylist(uri.id), this.spotify.getPlaylistTracks(uri.id, {limit: 50})]);
+
+    const items = tracksResponse.items.map(playlistItem => playlistItem.track);
+    const playlist = {title: playlistResponse.name, source: playlistResponse.href};
+
+    while (tracksResponse.next) {
+      // eslint-disable-next-line no-await-in-loop
+      ({body: tracksResponse} = await this.spotify.getPlaylistTracks(uri.id, {
+        limit: parseInt(new URL(tracksResponse.next).searchParams.get('limit') ?? '50', 10),
+        offset: parseInt(new URL(tracksResponse.next).searchParams.get('offset') ?? '0', 10),
+      }));
+
+      items.push(...tracksResponse.items.map(playlistItem => playlistItem.track));
+    }
+
+    const tracks = this.limitTracks(items, playlistLimit).map(this.toSpotifyTrack);
+
+    return [tracks, playlist];
+  }
+
+  async getTrack(url: string): Promise<SpotifyTrack> {
+    const uri = spotifyURI.parse(url) as spotifyURI.Track;
+    const {body} = await this.spotify.getTrack(uri.id);
+
+    return this.toSpotifyTrack(body);
+  }
+
+  async getArtist(url: string, playlistLimit: number): Promise<SpotifyTrack[]> {
+    const uri = spotifyURI.parse(url) as spotifyURI.Artist;
+    const {body} = await this.spotify.getArtistTopTracks(uri.id, 'US');
+
+    return this.limitTracks(body.tracks, playlistLimit).map(this.toSpotifyTrack);
+  }
+
+  private toSpotifyTrack(track: SpotifyApi.TrackObjectSimplified): SpotifyTrack {
+    return {
+      name: track.name,
+      artist: track.artists[0].name,
+    };
+  }
+
+  private limitTracks(tracks: SpotifyApi.TrackObjectSimplified[], limit: number) {
+    return tracks.length > limit ? shuffle(tracks).slice(0, limit) : tracks;
+  }
+}

--- a/src/services/youtube-api.ts
+++ b/src/services/youtube-api.ts
@@ -4,8 +4,7 @@ import got from 'got';
 import ytsr, {Video} from 'ytsr';
 import YouTube, {YoutubePlaylistItem, YoutubeVideo} from 'youtube.ts';
 import PQueue from 'p-queue';
-import {Except} from 'type-fest';
-import {QueuedSong, QueuedPlaylist, MediaSource} from './player.js';
+import {SongMetadata, QueuedPlaylist, MediaSource} from './player.js';
 import {TYPES} from '../types.js';
 import {cleanUrl} from '../utils/url.js';
 import ThirdParty from './third-party.js';
@@ -13,8 +12,6 @@ import Config from './config.js';
 import KeyValueCacheProvider from './key-value-cache.js';
 import {ONE_HOUR_IN_SECONDS, ONE_MINUTE_IN_SECONDS} from '../utils/constants.js';
 import {parseTime} from '../utils/time.js';
-
-type SongMetadata = Except<QueuedSong, 'addedInChannelId' | 'requestedBy'>;
 
 interface VideoDetailsResponse {
   id: string;

--- a/src/services/youtube-api.ts
+++ b/src/services/youtube-api.ts
@@ -1,0 +1,268 @@
+import {inject, injectable} from 'inversify';
+import {toSeconds, parse} from 'iso8601-duration';
+import got from 'got';
+import ytsr, {Video} from 'ytsr';
+import YouTube, {YoutubePlaylistItem, YoutubeVideo} from 'youtube.ts';
+import PQueue from 'p-queue';
+import {Except} from 'type-fest';
+import {QueuedSong, QueuedPlaylist, MediaSource} from './player.js';
+import {TYPES} from '../types.js';
+import {cleanUrl} from '../utils/url.js';
+import ThirdParty from './third-party.js';
+import Config from './config.js';
+import KeyValueCacheProvider from './key-value-cache.js';
+import {ONE_HOUR_IN_SECONDS, ONE_MINUTE_IN_SECONDS} from '../utils/constants.js';
+import {parseTime} from '../utils/time.js';
+
+type SongMetadata = Except<QueuedSong, 'addedInChannelId' | 'requestedBy'>;
+
+interface VideoDetailsResponse {
+  id: string;
+  contentDetails: {
+    videoId: string;
+    duration: string;
+  };
+}
+
+@injectable()
+export default class {
+  private readonly youtube: YouTube;
+  private readonly youtubeKey: string;
+  private readonly cache: KeyValueCacheProvider;
+
+  private readonly ytsrQueue: PQueue;
+
+  constructor(
+  @inject(TYPES.ThirdParty) thirdParty: ThirdParty,
+    @inject(TYPES.Config) config: Config,
+    @inject(TYPES.KeyValueCache) cache: KeyValueCacheProvider) {
+    this.youtube = thirdParty.youtube;
+    this.youtubeKey = config.YOUTUBE_API_KEY;
+    this.cache = cache;
+
+    this.ytsrQueue = new PQueue({concurrency: 4});
+  }
+
+  async search(query: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
+    const {items} = await this.ytsrQueue.add(async () => this.cache.wrap(
+      ytsr,
+      query,
+      {
+        limit: 10,
+      },
+      {
+        expiresIn: ONE_HOUR_IN_SECONDS,
+      },
+    ));
+
+    let firstVideo: Video | undefined;
+
+    for (const item of items) {
+      if (item.type === 'video') {
+        firstVideo = item;
+        break;
+      }
+    }
+
+    if (!firstVideo) {
+      throw new Error('No video found.');
+    }
+
+    return this.getVideo(firstVideo.id, shouldSplitChapters);
+  }
+
+  async getVideo(url: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
+    const video = await this.cache.wrap(
+      this.youtube.videos.get,
+      cleanUrl(url),
+      {
+        expiresIn: ONE_HOUR_IN_SECONDS,
+      },
+    );
+
+    return this.getMetadataFromVideo({video, shouldSplitChapters});
+  }
+
+  async getPlaylist(listId: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
+    // YouTube playlist
+    const playlist = await this.cache.wrap(
+      this.youtube.playlists.get,
+      listId,
+      {
+        expiresIn: ONE_MINUTE_IN_SECONDS,
+      },
+    );
+
+    const playlistVideos: YoutubePlaylistItem[] = [];
+    const videoDetailsPromises: Array<Promise<void>> = [];
+    const videoDetails: VideoDetailsResponse[] = [];
+
+    let nextToken: string | undefined;
+
+    while (playlistVideos.length !== playlist.contentDetails.itemCount) {
+      // eslint-disable-next-line no-await-in-loop
+      const {items, nextPageToken} = await this.cache.wrap(
+        this.youtube.playlists.items,
+        listId,
+        {maxResults: '50', pageToken: nextToken},
+        {
+          expiresIn: ONE_MINUTE_IN_SECONDS,
+        },
+      );
+
+      nextToken = nextPageToken;
+
+      playlistVideos.push(...items);
+
+      // Start fetching extra details about videos
+      videoDetailsPromises.push((async () => {
+        // Unfortunately, package doesn't provide a method for this
+        const p = {
+          searchParams: {
+            part: 'contentDetails',
+            id: items.map(item => item.contentDetails.videoId).join(','),
+            key: this.youtubeKey,
+            responseType: 'json',
+          },
+        };
+        const {items: videoDetailItems} = await this.cache.wrap(
+          async () => got(
+            'https://www.googleapis.com/youtube/v3/videos',
+            p,
+          ).json() as Promise<{items: VideoDetailsResponse[]}>,
+          p,
+          {
+            expiresIn: ONE_MINUTE_IN_SECONDS,
+          },
+        );
+
+        videoDetails.push(...videoDetailItems);
+      })());
+    }
+
+    await Promise.all(videoDetailsPromises);
+
+    const queuedPlaylist = {title: playlist.snippet.title, source: playlist.id};
+
+    const songsToReturn: SongMetadata[] = [];
+
+    for (const video of playlistVideos) {
+      try {
+        songsToReturn.push(...this.getMetadataFromVideo({
+          video,
+          queuedPlaylist,
+          videoDetails: videoDetails.find((i: {id: string}) => i.id === video.contentDetails.videoId),
+          shouldSplitChapters,
+        }));
+      } catch (_: unknown) {
+        // Private and deleted videos are sometimes in playlists, duration of these is not returned and they should not be added to the queue.
+      }
+    }
+
+    return songsToReturn;
+  }
+
+  // TODO: we should convert YouTube videos (from both single videos and playlists) to an intermediate representation so we don't have to check if it's from a playlist
+  private getMetadataFromVideo({
+    video,
+    queuedPlaylist,
+    videoDetails,
+    shouldSplitChapters,
+  }: {
+    video: YoutubeVideo | YoutubePlaylistItem;
+    queuedPlaylist?: QueuedPlaylist;
+    videoDetails?: VideoDetailsResponse;
+    shouldSplitChapters?: boolean;
+  }): SongMetadata[] {
+    let url: string;
+    let videoDurationSeconds: number;
+    // Dirty hack
+    if (queuedPlaylist) {
+      // Is playlist item
+      video = video as YoutubePlaylistItem;
+      url = video.contentDetails.videoId;
+      videoDurationSeconds = toSeconds(parse(videoDetails!.contentDetails.duration));
+    } else {
+      video = video as YoutubeVideo;
+      videoDurationSeconds = toSeconds(parse(video.contentDetails.duration));
+      url = video.id;
+    }
+
+    const base: SongMetadata = {
+      source: MediaSource.Youtube,
+      title: video.snippet.title,
+      artist: video.snippet.channelTitle,
+      length: videoDurationSeconds,
+      offset: 0,
+      url,
+      playlist: queuedPlaylist ?? null,
+      isLive: false,
+      thumbnailUrl: video.snippet.thumbnails.medium.url,
+    };
+
+    if (!shouldSplitChapters) {
+      return [base];
+    }
+
+    const chapters = this.parseChaptersFromDescription(video.snippet.description, videoDurationSeconds);
+
+    if (!chapters) {
+      return [base];
+    }
+
+    const tracks: SongMetadata[] = [];
+
+    for (const [label, {offset, length}] of chapters) {
+      tracks.push({
+        ...base,
+        offset,
+        length,
+        title: `${label} (${base.title})`,
+      });
+    }
+
+    return tracks;
+  }
+
+  private parseChaptersFromDescription(description: string, videoDurationSeconds: number) {
+    const map = new Map<string, {offset: number; length: number}>();
+    let foundFirstTimestamp = false;
+
+    const foundTimestamps: Array<{name: string; offset: number}> = [];
+    for (const line of description.split('\n')) {
+      const timestamps = Array.from(line.matchAll(/(?:\d+:)+\d+/g));
+      if (timestamps?.length !== 1) {
+        continue;
+      }
+
+      if (!foundFirstTimestamp) {
+        if (/0{1,2}:00/.test(timestamps[0][0])) {
+          foundFirstTimestamp = true;
+        } else {
+          continue;
+        }
+      }
+
+      const timestamp = timestamps[0][0];
+      const seconds = parseTime(timestamp);
+      const chapterName = line.split(timestamp)[1].trim();
+
+      foundTimestamps.push({name: chapterName, offset: seconds});
+    }
+
+    for (const [i, {name, offset}] of foundTimestamps.entries()) {
+      map.set(name, {
+        offset,
+        length: i === foundTimestamps.length - 1
+          ? videoDurationSeconds - offset
+          : foundTimestamps[i + 1].offset - offset,
+      });
+    }
+
+    if (!map.size) {
+      return null;
+    }
+
+    return map;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,5 +13,7 @@ export const TYPES = {
   Services: {
     AddQueryToQueue: Symbol('AddQueryToQueue'),
     GetSongs: Symbol('GetSongs'),
+    YoutubeAPI: Symbol('YoutubeAPI'),
+    SpotifyAPI: Symbol('SpotifyAPI'),
   },
 };


### PR DESCRIPTION
Closes #396 

- Allow streaming from a url like  https://nightride.fm/stream/rektory.m4a , https://nightride.fm/stream/nightride.mp3  as mentioned in #396 
- Refactor get-songs - extracted into YoutubeAPI and Spotify API that handles the call and data parsing logic that returns a simple object for get-songs to aggregate and map into SongMetadata.

- [ ] I updated the changelog
