### PR TITLE
add /next command as alias for /skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a case-sensitive import issue
 
+### Added
+- Added a `/next` alias for `/skip`
+
 ## [1.8.2] - 2022-03-27
 ### Fixed
 - `/fseek` now works again

--- a/src/commands/next.ts
+++ b/src/commands/next.ts
@@ -1,0 +1,10 @@
+import {injectable} from 'inversify';
+import Skip from './skip.js';
+import {SlashCommandBuilder} from '@discordjs/builders';
+
+@injectable()
+export default class extends Skip {
+  public readonly slashCommand = new SlashCommandBuilder()
+    .setName('next')
+    .setDescription('skip to the next song');
+}

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -31,6 +31,7 @@ import Resume from './commands/resume.js';
 import Seek from './commands/seek.js';
 import Shuffle from './commands/shuffle.js';
 import Skip from './commands/skip.js';
+import Next from './commands/next.js';
 import Stop from './commands/stop.js';
 import Unskip from './commands/unskip.js';
 import ThirdParty from './services/third-party.js';
@@ -77,6 +78,7 @@ container.bind<SpotifyAPI>(TYPES.Services.SpotifyAPI).to(SpotifyAPI).inSingleton
   Seek,
   Shuffle,
   Skip,
+  Next,
   Stop,
   Unskip,
 ].forEach(command => {


### PR DESCRIPTION
Closes #625
Added a file next.js which extends the skip.js default class. Due to the default behaviour of skip.js execute function no further changes had to be made.

- added next.js
- added entry in inversify.config.ts
