### PR TITLE
Add /loop support for individual songs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- `/loop` command that plays the current song on loop
+
 
 ## [2.0.4] - 2022-05-16
 ### Fixed

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -27,8 +27,8 @@ export default class implements Command {
       throw new Error('no song to loop!');
     }
 
-    player.loop();
+    player.loopCurrentSong = !player.loopCurrentSong;
 
-    await interaction.reply((player.isLoopingSong() ? 'looped :)' : 'stopped looping :('));
+    await interaction.reply((player.loopCurrentSong ? 'looped :)' : 'stopped looping :('));
   }
 }

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -1,0 +1,34 @@
+import {ChatInputCommandInteraction} from 'discord.js';
+import {TYPES} from '../types.js';
+import {inject, injectable} from 'inversify';
+import PlayerManager from '../managers/player.js';
+import Command from '.';
+import {SlashCommandBuilder} from '@discordjs/builders';
+import {STATUS} from '../services/player';
+
+@injectable()
+export default class implements Command {
+  public readonly slashCommand = new SlashCommandBuilder()
+    .setName('loop')
+    .setDescription('toggle looping the current song');
+
+  public requiresVC = true;
+
+  private readonly playerManager: PlayerManager;
+
+  constructor(@inject(TYPES.Managers.Player) playerManager: PlayerManager) {
+    this.playerManager = playerManager;
+  }
+
+  public async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const player = this.playerManager.get(interaction.guild!.id);
+
+    if (player.status === STATUS.IDLE) {
+      throw new Error('no song to loop!');
+    }
+
+    player.loop();
+
+    await interaction.reply((player.isLoopingSong() ? 'looped :)' : 'stopped looping :('));
+  }
+}

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -37,6 +37,7 @@ import Unskip from './commands/unskip.js';
 import ThirdParty from './services/third-party.js';
 import FileCacheProvider from './services/file-cache.js';
 import KeyValueCacheProvider from './services/key-value-cache.js';
+import Loop from './commands/loop';
 
 const container = new Container();
 
@@ -79,6 +80,7 @@ container.bind<SpotifyAPI>(TYPES.Services.SpotifyAPI).to(SpotifyAPI).inSingleton
   Next,
   Stop,
   Unskip,
+  Loop,
 ].forEach(command => {
   container.bind<Command>(TYPES.Command).to(command).inSingletonScope();
 });

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -60,6 +60,7 @@ export default class {
   public voiceConnection: VoiceConnection | null = null;
   public status = STATUS.PAUSED;
   public guildId: string;
+  public loopCurrentSong = false;
 
   private queue: QueuedSong[] = [];
   private queuePosition = 0;
@@ -67,7 +68,6 @@ export default class {
   private nowPlaying: QueuedSong | null = null;
   private playPositionInterval: NodeJS.Timeout | undefined;
   private lastSongURL = '';
-  private loopCurrentSong = false;
 
   private positionInSeconds = 0;
   private readonly fileCache: FileCacheProvider;
@@ -92,24 +92,13 @@ export default class {
         this.pause();
       }
 
+      this.loopCurrentSong = false;
       this.voiceConnection.destroy();
       this.audioPlayer?.stop();
 
       this.voiceConnection = null;
       this.audioPlayer = null;
     }
-  }
-
-  loop(): void {
-    if (this.status === STATUS.PLAYING) {
-      this.loopCurrentSong = !this.loopCurrentSong;
-    } else {
-      throw new Error('Not currently playing song');
-    }
-  }
-
-  isLoopingSong() {
-    return this.loopCurrentSong;
   }
 
   async seek(positionSeconds: number): Promise<void> {

--- a/src/utils/build-embed.ts
+++ b/src/utils/build-embed.ts
@@ -119,7 +119,7 @@ export const buildQueueEmbed = (player: Player, page: number): EmbedBuilder => {
   }
 
   message
-    .setTitle(player.status === STATUS.PLAYING ? 'Now Playing' : 'Queued songs')
+    .setTitle(player.status === STATUS.PLAYING ? `Now Playing ${player.loopCurrentSong ? '(loop on)' : ''}` : 'Queued songs')
     .setColor(player.status === STATUS.PLAYING ? 'DarkGreen' : 'NotQuiteBlack')
     .setDescription(description)
     .addFields([{name: 'In queue', value: getQueueInfo(player), inline: true}, {

--- a/src/utils/build-embed.ts
+++ b/src/utils/build-embed.ts
@@ -46,8 +46,8 @@ const getPlayerUI = (player: Player) => {
   const button = player.status === STATUS.PLAYING ? '⏹️' : '▶️';
   const progressBar = getProgressBar(15, position / song.length);
   const elapsedTime = song.isLive ? 'live' : `${prettyTime(position)}/${prettyTime(song.length)}`;
-
-  return `${button} ${progressBar} \`[${elapsedTime}]\` 🔉`;
+  const loop = player.loopCurrentSong ? '🔁' : '';
+  return `${button} ${progressBar} \`[${elapsedTime}]\` 🔉 ${loop}`;
 };
 
 export const buildPlayingMessageEmbed = (player: Player): EmbedBuilder => {


### PR DESCRIPTION
Closes #524

<!-- A brief description of changes -->
Adds a /loop command, which loops current song. When the bot disconnects or a user runs /loop again it stops looping. 

Does not currently display anywhere if current song is looping, lmk if you think that is necessary and where it would best belong.


- [✅] I updated the changelog
