### PR TITLE
Minor message improvements

### DIFF
--- a/src/commands/disconnect.ts
+++ b/src/commands/disconnect.ts
@@ -28,6 +28,6 @@ export default class implements Command {
 
     player.disconnect();
 
-    await interaction.reply('u betcha');
+    await interaction.reply('u betcha, disconnected');
   }
 }

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -32,6 +32,6 @@ export default class implements Command {
     }
 
     player.stop();
-    await interaction.reply('u betcha');
+    await interaction.reply('u betcha, stopped');
   }
 }

--- a/src/utils/error-msg.ts
+++ b/src/utils/error-msg.ts
@@ -3,9 +3,9 @@ export default (error?: string | Error): string => {
 
   if (error) {
     if (typeof error === 'string') {
-      str = `🚫ope: ${error}`;
+      str = `🚫 ope: ${error}`;
     } else if (error instanceof Error) {
-      str = `🚫ope: ${error.message}`;
+      str = `🚫 ope: ${error.message}`;
     }
   }
 


### PR DESCRIPTION
Makes error messages look nicer by adding a space between the 🚫 and the ope
old: `🚫ope`
new: `🚫 ope`

make stop and disconnect success messages more descriptive by adding stopped and disconnected after. 
old: `u betcha`
new: `u betcha, stopped`
This is useful because if someone does a command, other users will get a notification saying "u betcha", with no context as to what command was executed.