### PR TITLE
Temporary workaround for VoiceConnection stuck in signalling state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add temporary workaround to avoid VoiceConnection being stuck in signalling state
 
 ## [2.2.0] - 2023-02-26
 ### Added

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -87,16 +87,18 @@ export default class {
 
     // Workaround to disable keepAlive
     this.voiceConnection.on('stateChange', (oldState, newState) => {
+      /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
       const oldNetworking = Reflect.get(oldState, 'networking');
       const newNetworking = Reflect.get(newState, 'networking');
-    
-      const networkStateChangeHandler = (oldNetworkState: any, newNetworkState: any) => {
+
+      const networkStateChangeHandler = (_: any, newNetworkState: any) => {
         const newUdp = Reflect.get(newNetworkState, 'udp');
         clearInterval(newUdp?.keepAliveInterval);
-      }
-    
+      };
+
       oldNetworking?.off('stateChange', networkStateChangeHandler);
       newNetworking?.on('stateChange', networkStateChangeHandler);
+      /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
     });
   }
 

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -84,6 +84,20 @@ export default class {
       guildId: channel.guild.id,
       adapterCreator: channel.guild.voiceAdapterCreator as DiscordGatewayAdapterCreator,
     });
+
+    // Workaround to disable keepAlive
+    this.voiceConnection.on('stateChange', (oldState, newState) => {
+      const oldNetworking = Reflect.get(oldState, 'networking');
+      const newNetworking = Reflect.get(newState, 'networking');
+    
+      const networkStateChangeHandler = (oldNetworkState: any, newNetworkState: any) => {
+        const newUdp = Reflect.get(newNetworkState, 'udp');
+        clearInterval(newUdp?.keepAliveInterval);
+      }
+    
+      oldNetworking?.off('stateChange', networkStateChangeHandler);
+      newNetworking?.on('stateChange', networkStateChangeHandler);
+    });
   }
 
   disconnect(): void {


### PR DESCRIPTION
Closes #844 #906 

Workaround proposed in https://github.com/discordjs/discord.js/issues/9185#issuecomment-1452514375
This workaround disables the keepAlive timer/interval in discord.js that causes the issue.

I don't know if it's better to merge this PR until discord.js is updated with the proper fix or to directly wait for the update. I'm still creating this PR to at least trigger a snapshot build.

- [x] I updated the changelog
