### PR TITLE
Create guild settings if not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Create the guild settings when not found instead of returning an error
 
 ## [2.2.0] - 2023-02-26
 ### Added

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -3,6 +3,7 @@ import {ChatInputCommandInteraction, EmbedBuilder, PermissionFlagsBits} from 'di
 import {injectable} from 'inversify';
 import {prisma} from '../utils/db.js';
 import Command from './index.js';
+import {getGuildSettings} from '../utils/get-guild-settings';
 
 @injectable()
 export default class implements Command {
@@ -96,11 +97,7 @@ export default class implements Command {
       case 'get': {
         const embed = new EmbedBuilder().setTitle('Config');
 
-        const config = await prisma.setting.findUnique({where: {guildId: interaction.guild!.id}});
-
-        if (!config) {
-          throw new Error('no config found');
-        }
+        const config = await getGuildSettings(interaction.guild!.id);
 
         const settingsToShow = {
           'Playlist Limit': config.playlistLimit,

--- a/src/events/guild-create.ts
+++ b/src/events/guild-create.ts
@@ -8,20 +8,20 @@ import {REST} from '@discordjs/rest';
 import {Setting} from '@prisma/client';
 import registerCommandsOnGuild from '../utils/register-commands-on-guild.js';
 
-export async function createGuildSettings(guild: Guild): Promise<Setting> {
+export async function createGuildSettings(guildId: string): Promise<Setting> {
   return prisma.setting.upsert({
     where: {
-      guildId: guild.id,
+      guildId,
     },
     create: {
-      guildId: guild.id,
+      guildId,
     },
     update: {},
   });
 }
 
 export default async (guild: Guild): Promise<void> => {
-  await createGuildSettings(guild);
+  await createGuildSettings(guild.id);
 
   const config = container.get<Config>(TYPES.Config);
 

--- a/src/events/voice-state-update.ts
+++ b/src/events/voice-state-update.ts
@@ -3,7 +3,7 @@ import container from '../inversify.config.js';
 import {TYPES} from '../types.js';
 import PlayerManager from '../managers/player.js';
 import {getSizeWithoutBots} from '../utils/channels.js';
-import {prisma} from '../utils/db.js';
+import {getGuildSettings} from '../utils/get-guild-settings';
 
 export default async (oldState: VoiceState, _: VoiceState): Promise<void> => {
   const playerManager = container.get<PlayerManager>(TYPES.Managers.Player);
@@ -12,11 +12,7 @@ export default async (oldState: VoiceState, _: VoiceState): Promise<void> => {
 
   if (player.voiceConnection) {
     const voiceChannel: VoiceChannel = oldState.guild.channels.cache.get(player.voiceConnection.joinConfig.channelId!) as VoiceChannel;
-    const settings = await prisma.setting.findUnique({where: {guildId: player.guildId}});
-
-    if (!settings) {
-      throw new Error('Could not find settings for guild');
-    }
+    const settings = await getGuildSettings(player.guildId);
 
     const {leaveIfNoListeners} = settings;
     if (!voiceChannel || (getSizeWithoutBots(voiceChannel) === 0 && leaveIfNoListeners)) {

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -6,9 +6,9 @@ import {TYPES} from '../types.js';
 import GetSongs from '../services/get-songs.js';
 import {SongMetadata, STATUS} from './player.js';
 import PlayerManager from '../managers/player.js';
-import {prisma} from '../utils/db.js';
 import {buildPlayingMessageEmbed} from '../utils/build-embed.js';
 import {getMemberVoiceChannel, getMostPopularVoiceChannel} from '../utils/channels.js';
+import {getGuildSettings} from '../utils/get-guild-settings';
 
 @injectable()
 export default class AddQueryToQueue {
@@ -34,11 +34,7 @@ export default class AddQueryToQueue {
 
     const [targetVoiceChannel] = getMemberVoiceChannel(interaction.member as GuildMember) ?? getMostPopularVoiceChannel(interaction.guild!);
 
-    const settings = await prisma.setting.findUnique({where: {guildId}});
-
-    if (!settings) {
-      throw new Error('Could not find settings for guild');
-    }
+    const settings = await getGuildSettings(guildId);
 
     const {playlistLimit} = settings;
 

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -18,7 +18,7 @@ import {
 } from '@discordjs/voice';
 import FileCacheProvider from './file-cache.js';
 import debug from '../utils/debug.js';
-import {prisma} from '../utils/db.js';
+import {getGuildSettings} from '../utils/get-guild-settings';
 
 export enum MediaSource {
   Youtube,
@@ -256,11 +256,7 @@ export default class {
         this.audioPlayer?.stop();
         this.status = STATUS.IDLE;
 
-        const settings = await prisma.setting.findUnique({where: {guildId: this.guildId}});
-
-        if (!settings) {
-          throw new Error('Could not find settings for guild');
-        }
+        const settings = await getGuildSettings(this.guildId);
 
         const {secondsToWaitAfterQueueEmpties} = settings;
         if (secondsToWaitAfterQueueEmpties !== 0) {

--- a/src/utils/get-guild-settings.ts
+++ b/src/utils/get-guild-settings.ts
@@ -1,0 +1,12 @@
+import {Setting} from '@prisma/client';
+import {prisma} from './db';
+import {createGuildSettings} from '../events/guild-create';
+
+export async function getGuildSettings(guildId: string): Promise<Setting> {
+  const config = await prisma.setting.findUnique({where: {guildId}});
+  if (!config) {
+    return createGuildSettings(guildId);
+  }
+
+  return config;
+}


### PR DESCRIPTION
Closes #910 

Created a utility method `getGuildSettings()` that creates a new guild settings if not found and replaced all the Prisma queries with the new `getGuildSettings()` method.

- [x] I updated the changelog
