### PR TITLE
Autocomplete Suggestion Improvements for Favorites Use Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.4.0] - 2023-07-19
+## [2.4.1] - 2023-07-21
+### Fixed
+- Autocomplete suggestion search for `favorites use` command is no longer case-sensitive
+- Autocomplete suggestion results for `favorites use` could return >25 results which Discord's API does not support
 
 ## [2.4.0] - 2023-07-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.4.1] - 2023-07-21
 ### Fixed
 - Autocomplete suggestion search for `favorites use` command is no longer case-sensitive
 - Autocomplete suggestion results for `favorites use` could return >25 results which Discord's API does not support

--- a/src/commands/favorites.ts
+++ b/src/commands/favorites.ts
@@ -96,7 +96,9 @@ export default class implements Command {
       results = interaction.member?.user.id === interaction.guild?.ownerId ? results : results.filter(r => r.authorId === interaction.member!.user.id);
     }
 
-    await interaction.respond(results.map(r => ({
+    // Limit results to 25 maximum per Discord limits
+    const trimmed = results.length > 25 ? results.slice(0, 25) : results;
+    await interaction.respond(trimmed.map(r => ({
       name: r.name,
       value: r.name,
     })));

--- a/src/commands/favorites.ts
+++ b/src/commands/favorites.ts
@@ -89,7 +89,7 @@ export default class implements Command {
       },
     });
 
-    let results = query === '' ? favorites : favorites.filter(f => f.name.startsWith(query));
+    let results = query === '' ? favorites : favorites.filter(f => f.name.toLowerCase().startsWith(query.toLowerCase()));
 
     if (subcommand === 'remove') {
       // Only show favorites that user is allowed to remove


### PR DESCRIPTION
This introduces two minor fixes:
* When using the `favorites use` command, if >25 results were returned no results were displayed as Discord's API does not permit  lists larger than 25.
* When searching the autocomplete suggestions for `favorites use` searches were case sensitive making searching more difficult.

- [x] I updated the changelog
