### PR TITLE
Bump node-ytsr version to 3.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bumped node-ytsr ([#948](https://github.com/codetheweb/muse/issues/948))
+
 ## [2.4.1] - 2023-07-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "tsx": "3.8.2",
     "xbytes": "^1.7.0",
     "ytdl-core": "^4.11.5",
-    "ytsr": "^3.8.2"
+    "ytsr": "^3.8.4"
   },
   "resolutions": {
     "@types/ws": "8.5.4"


### PR DESCRIPTION
Closes #948

The issue was in [node-ytsr](https://github.com/TimeForANinja/node-ytsr/) and was [fixed yesterday](https://github.com/TimeForANinja/node-ytsr/pull/203). We simply need to upgrade to [v3.8.4](https://github.com/TimeForANinja/node-ytsr/releases/tag/v3.8.4).

- [x] I updated the changelog