### PR TITLE
Optimize docker memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Optimized Docker container to run JS code directly with node instead of yarn, npm and tsx. Reduces memory usage. 
+
 ## [2.4.3] - 2023-09-10
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,28 @@ COPY package.json .
 COPY yarn.lock .
 
 RUN yarn install --prod
+RUN cp -R node_modules /usr/app/prod_node_modules
+
+RUN yarn install
+
+FROM dependencies AS builder
+
+COPY . .
+
+# Run tsc build
+RUN yarn prisma generate
+RUN yarn build
 
 # Only keep what's necessary to run
 FROM base AS runner
 
 WORKDIR /usr/app
 
-COPY --from=dependencies /usr/app/node_modules node_modules
+COPY --from=builder /usr/app/dist ./dist
+COPY --from=dependencies /usr/app/prod_node_modules node_modules
+COPY --from=builder /usr/app/node_modules/.prisma/client ./node_modules/.prisma/client
 
 COPY . .
-
-RUN yarn prisma generate
 
 ARG COMMIT_HASH=unknown
 ARG BUILD_DATE=unknown
@@ -34,4 +45,6 @@ ENV NODE_ENV production
 ENV COMMIT_HASH $COMMIT_HASH
 ENV BUILD_DATE $BUILD_DATE
 
-CMD ["tini", "--", "yarn", "start"]
+RUN echo "DATABASE_URL=$(node dist/scripts/print-database-url.js)" > .env
+
+CMD ["tini", "--", "node", "dist/scripts/migrate-and-start.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,4 @@ ENV NODE_ENV production
 ENV COMMIT_HASH $COMMIT_HASH
 ENV BUILD_DATE $BUILD_DATE
 
-RUN echo "DATABASE_URL=$(node dist/scripts/print-database-url.js)" > .env
-
-CMD ["tini", "--", "node", "dist/scripts/migrate-and-start.js"]
+CMD ["tini", "--", "node", "--enable-source-maps", "dist/scripts/migrate-and-start.js"]

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "migrations:run": "npm run prisma:with-env migrate deploy",
     "prisma:with-env": "npm run env:set-database-url prisma",
     "env:set-database-url": "tsx src/scripts/run-with-database-url.ts",
-    "release": "release-it"
+    "release": "release-it",
+    "build": "tsc"
   },
   "devDependencies": {
     "@release-it/keep-a-changelog": "^2.3.0",

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -3,7 +3,7 @@ import {ChatInputCommandInteraction, EmbedBuilder, PermissionFlagsBits} from 'di
 import {injectable} from 'inversify';
 import {prisma} from '../utils/db.js';
 import Command from './index.js';
-import {getGuildSettings} from '../utils/get-guild-settings';
+import {getGuildSettings} from '../utils/get-guild-settings.js';
 
 @injectable()
 export default class implements Command {

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -4,7 +4,7 @@ import {inject, injectable} from 'inversify';
 import PlayerManager from '../managers/player.js';
 import Command from '.';
 import {SlashCommandBuilder} from '@discordjs/builders';
-import {STATUS} from '../services/player';
+import {STATUS} from '../services/player.js';
 
 @injectable()
 export default class implements Command {

--- a/src/events/voice-state-update.ts
+++ b/src/events/voice-state-update.ts
@@ -3,7 +3,7 @@ import container from '../inversify.config.js';
 import {TYPES} from '../types.js';
 import PlayerManager from '../managers/player.js';
 import {getSizeWithoutBots} from '../utils/channels.js';
-import {getGuildSettings} from '../utils/get-guild-settings';
+import {getGuildSettings} from '../utils/get-guild-settings.js';
 
 export default async (oldState: VoiceState, _: VoiceState): Promise<void> => {
   const playerManager = container.get<PlayerManager>(TYPES.Managers.Player);

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -21,7 +21,7 @@ import Config from './commands/config.js';
 import Disconnect from './commands/disconnect.js';
 import Favorites from './commands/favorites.js';
 import ForwardSeek from './commands/fseek.js';
-import Loop from './commands/loop';
+import Loop from './commands/loop.js';
 import Move from './commands/move.js';
 import Next from './commands/next.js';
 import NowPlaying from './commands/now-playing.js';

--- a/src/scripts/migrate-and-start.ts
+++ b/src/scripts/migrate-and-start.ts
@@ -15,7 +15,12 @@ import {DATA_DIR} from '../services/config.js';
 const client = new Prisma.PrismaClient();
 
 const migrateFromSequelizeToPrisma = async () => {
-  await execa('prisma', ['migrate', 'resolve', '--applied', '20220101155430_migrate_from_sequelize'], {preferLocal: true});
+  await execa('prisma', ['migrate', 'resolve', '--applied', '20220101155430_migrate_from_sequelize'], {
+    preferLocal: true,
+    env: {
+      DATABASE_URL: process.env.DATABASE_URL,
+    },
+  });
 };
 
 const doesUserHaveExistingDatabase = async () => {

--- a/src/scripts/migrate-and-start.ts
+++ b/src/scripts/migrate-and-start.ts
@@ -14,7 +14,7 @@ import {DATA_DIR} from '../services/config.js';
 
 const client = new Prisma.PrismaClient();
 
-process.env.DATABASE_URL = process.env.DATABASE_URL || createDatabaseUrl(DATA_DIR)
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? createDatabaseUrl(DATA_DIR);
 
 const migrateFromSequelizeToPrisma = async () => {
   await execa('prisma', ['migrate', 'resolve', '--applied', '20220101155430_migrate_from_sequelize'], {preferLocal: true});

--- a/src/scripts/migrate-and-start.ts
+++ b/src/scripts/migrate-and-start.ts
@@ -9,18 +9,15 @@ import Prisma from '@prisma/client';
 import ora from 'ora';
 import {startBot} from '../index.js';
 import logBanner from '../utils/log-banner.js';
-import {createDatabasePath} from '../utils/create-database-url.js';
+import createDatabaseUrl, {createDatabasePath} from '../utils/create-database-url.js';
 import {DATA_DIR} from '../services/config.js';
 
 const client = new Prisma.PrismaClient();
 
+process.env.DATABASE_URL = process.env.DATABASE_URL || createDatabaseUrl(DATA_DIR)
+
 const migrateFromSequelizeToPrisma = async () => {
-  await execa('prisma', ['migrate', 'resolve', '--applied', '20220101155430_migrate_from_sequelize'], {
-    preferLocal: true,
-    env: {
-      DATABASE_URL: process.env.DATABASE_URL,
-    },
-  });
+  await execa('prisma', ['migrate', 'resolve', '--applied', '20220101155430_migrate_from_sequelize'], {preferLocal: true});
 };
 
 const doesUserHaveExistingDatabase = async () => {

--- a/src/scripts/print-database-url.ts
+++ b/src/scripts/print-database-url.ts
@@ -1,0 +1,4 @@
+import createDatabaseUrl from '../utils/create-database-url.js';
+import {DATA_DIR} from '../services/config.js';
+
+console.log(createDatabaseUrl(DATA_DIR));

--- a/src/scripts/print-database-url.ts
+++ b/src/scripts/print-database-url.ts
@@ -1,4 +1,0 @@
-import createDatabaseUrl from '../utils/create-database-url.js';
-import {DATA_DIR} from '../services/config.js';
-
-console.log(createDatabaseUrl(DATA_DIR));

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -9,7 +9,7 @@ import {SongMetadata, STATUS} from './player.js';
 import PlayerManager from '../managers/player.js';
 import {buildPlayingMessageEmbed} from '../utils/build-embed.js';
 import {getMemberVoiceChannel, getMostPopularVoiceChannel} from '../utils/channels.js';
-import {getGuildSettings} from '../utils/get-guild-settings';
+import {getGuildSettings} from '../utils/get-guild-settings.js';
 
 @injectable()
 export default class AddQueryToQueue {

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -1,6 +1,6 @@
 import {inject, injectable} from 'inversify';
 import * as spotifyURI from 'spotify-uri';
-import {SongMetadata, QueuedPlaylist, MediaSource} from './player';
+import {SongMetadata, QueuedPlaylist, MediaSource} from './player.js';
 import {TYPES} from '../types.js';
 import ffmpeg from 'fluent-ffmpeg';
 import YoutubeAPI from './youtube-api.js';

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -18,7 +18,7 @@ import {
 } from '@discordjs/voice';
 import FileCacheProvider from './file-cache.js';
 import debug from '../utils/debug.js';
-import {getGuildSettings} from '../utils/get-guild-settings';
+import {getGuildSettings} from '../utils/get-guild-settings.js';
 
 export enum MediaSource {
   Youtube,

--- a/src/utils/get-guild-settings.ts
+++ b/src/utils/get-guild-settings.ts
@@ -1,6 +1,6 @@
 import {Setting} from '@prisma/client';
-import {prisma} from './db';
-import {createGuildSettings} from '../events/guild-create';
+import {prisma} from './db.js';
+import {createGuildSettings} from '../events/guild-create.js';
 
 export async function getGuildSettings(guildId: string): Promise<Setting> {
   const config = await prisma.setting.findUnique({where: {guildId}});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "experimentalDecorators": true,
     "esModuleInterop": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "resolveJsonModule": true,
     "outDir": "dist"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,9 @@
     "strict": true,
     "experimentalDecorators": true,
     "esModuleInterop": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "resolveJsonModule": true,
-    "noEmit": true
+    "outDir": "dist"
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
<!-- A brief description of changes -->

When running this bot in docker container on my VPS server I encountered high ram usage. After investigation I found out that it runs with chain of yarn/npm/tsx/run-with-database-url.ts. 

In this PR I:

* Fixed imports to make code work after `tsc`.
* Added compilation stage with `tsc`.
* Replaced `run-with-database-url.ts` with simpler solution that doesn't run additional node processes in runtime.
* Replaced `yarn start` with direct invocation of node in `dockerfile`.

Before PR docker stats displayed 300-400mb of memory usage. Now it's 60-120mb.

- [x] I updated the changelog
