### PR TITLE
fix: Ensure guild settings exist in DB before updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "migrations:generate": "npm run prisma:with-env migrate dev",
     "migrations:run": "npm run prisma:with-env migrate deploy",
     "prisma:with-env": "npm run env:set-database-url prisma",
+    "prisma:generate": "prisma generate",
     "env:set-database-url": "tsx src/scripts/run-with-database-url.ts",
     "release": "release-it",
     "build": "tsc"

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -38,6 +38,9 @@ export default class implements Command {
       .setDescription('show all settings'));
 
   async execute(interaction: ChatInputCommandInteraction) {
+    // Ensure guild settings exist before trying to update
+    await getGuildSettings(interaction.guild!.id);
+
     switch (interaction.options.getSubcommand()) {
       case 'set-playlist-limit': {
         const limit: number = interaction.options.getInteger('limit')!;


### PR DESCRIPTION
If a user:

* runs muse and adds the bot to their guild
* deletes database (EX recreates docker container)
* runs muse and tries to update config before doing anything else

Then muse tries to update settings that were not created since guild-create event was not fired due to bot already existing in user's guild.

Fix this by always getting/creating guild settings before updating any from config command
