### PR TITLE
refactor: Optimize apt commands and dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
 FROM node:18.7.0-slim AS base
 
+# openssl will be a required package if base is updated to 18.16+ due to node:*-slim base distro change
+# https://github.com/prisma/prisma/issues/19729#issuecomment-1591270599
 # Install ffmpeg
-RUN apt-get update && \
-    apt-get install -y ffmpeg tini libssl-dev ca-certificates git && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+    ffmpeg \
+    tini \
+    openssl \
+    ca-certificates \
+    git \
+    && apt-get autoclean \
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies
 FROM base AS dependencies


### PR DESCRIPTION
* Use prod version of openssl to avoid packaging unnecessary development dependencies in image layer
* Use `--no-install-recommends` arg to avoid installing unnecessary suggested packages
* autoclean and autoremove for good measure

Reduces image layer by ~100MB
