### PR TITLE
Added config to make add to queue responses for requester only

### DIFF
--- a/migrations/20240419211843_add_queue_add_response_for_requester_only/migration.sql
+++ b/migrations/20240419211843_add_queue_add_response_for_requester_only/migration.sql
@@ -1,0 +1,18 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Setting" (
+    "guildId" TEXT NOT NULL PRIMARY KEY,
+    "playlistLimit" INTEGER NOT NULL DEFAULT 50,
+    "secondsToWaitAfterQueueEmpties" INTEGER NOT NULL DEFAULT 30,
+    "leaveIfNoListeners" BOOLEAN NOT NULL DEFAULT true,
+    "queueAddResponseEphemeral" BOOLEAN NOT NULL DEFAULT false,
+    "autoAnnounceNextSong" BOOLEAN NOT NULL DEFAULT false,
+    "defaultVolume" INTEGER NOT NULL DEFAULT 100,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Setting" ("autoAnnounceNextSong", "createdAt", "defaultVolume", "guildId", "leaveIfNoListeners", "playlistLimit", "secondsToWaitAfterQueueEmpties", "updatedAt") SELECT "autoAnnounceNextSong", "createdAt", "defaultVolume", "guildId", "leaveIfNoListeners", "playlistLimit", "secondsToWaitAfterQueueEmpties", "updatedAt" FROM "Setting";
+DROP TABLE "Setting";
+ALTER TABLE "new_Setting" RENAME TO "Setting";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/schema.prisma
+++ b/schema.prisma
@@ -28,6 +28,7 @@ model Setting {
   playlistLimit                  Int      @default(50)
   secondsToWaitAfterQueueEmpties Int      @default(30)
   leaveIfNoListeners             Boolean  @default(true)
+  queueAddResponseEphemeral      Boolean  @default(false)
   autoAnnounceNextSong           Boolean  @default(false)
   defaultVolume                  Int      @default(100)
   createdAt                      DateTime @default(now())

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -34,11 +34,11 @@ export default class implements Command {
         .setDescription('whether to leave when everyone else leaves')
         .setRequired(true)))
     .addSubcommand(subcommand => subcommand
-      .setName('set-queue-add-response-eph')
-      .setDescription('set whether bot responses to queue adds are only displayed to the requester')
+      .setName('set-queue-add-response-hidden')
+      .setDescription('set whether bot responses to queue additions are only displayed to the requester')
       .addBooleanOption(option => option
         .setName('value')
-        .setDescription('whether bot responses to queue adds are only displayed to the requester')
+        .setDescription('whether bot responses to queue additions are only displayed to the requester')
         .setRequired(true)))
     .addSubcommand(subcommand => subcommand
       .setName('set-auto-announce-next-song')

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -34,6 +34,13 @@ export default class implements Command {
         .setDescription('whether to leave when everyone else leaves')
         .setRequired(true)))
     .addSubcommand(subcommand => subcommand
+      .setName('set-queue-add-response-eph')
+      .setDescription('set whether bot responses to queue adds are only displayed to the requester')
+      .addBooleanOption(option => option
+        .setName('value')
+        .setDescription('whether bot responses to queue adds are only displayed to the requester')
+        .setRequired(true)))
+    .addSubcommand(subcommand => subcommand
       .setName('set-auto-announce-next-song')
       .setDescription('set whether to announce the next song in the queue automatically')
       .addBooleanOption(option => option
@@ -113,6 +120,23 @@ export default class implements Command {
         break;
       }
 
+      case 'set-queue-add-response-eph': {
+        const value = interaction.options.getBoolean('value')!;
+
+        await prisma.setting.update({
+          where: {
+            guildId: interaction.guild!.id,
+          },
+          data: {
+            queueAddResponseEphemeral: value,
+          },
+        });
+
+        await interaction.reply('👍 queue add notification setting updated');
+
+        break;
+      }
+
       case 'set-auto-announce-next-song': {
         const value = interaction.options.getBoolean('value')!;
 
@@ -159,6 +183,7 @@ export default class implements Command {
             : `${config.secondsToWaitAfterQueueEmpties}s`,
           'Leave if there are no listeners': config.leaveIfNoListeners ? 'yes' : 'no',
           'Auto announce next song in queue': config.autoAnnounceNextSong ? 'yes' : 'no',
+          'Add to queue reponses show for requester only': config.autoAnnounceNextSong ? 'yes' : 'no',
           'Default Volume': config.defaultVolume,
         };
 

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -37,9 +37,9 @@ export default class AddQueryToQueue {
 
     const settings = await getGuildSettings(guildId);
 
-    const {playlistLimit} = settings;
+    const {playlistLimit, queueAddResponseEphemeral} = settings;
 
-    await interaction.deferReply();
+    await interaction.deferReply({ephemeral: queueAddResponseEphemeral});
 
     let newSongs: SongMetadata[] = [];
     let extraMsg = '';


### PR DESCRIPTION
Added config to make add to queue responses for requester only

This was my first time using Prisma, so you may want to verify that database migration is working.