### PR TITLE
Stop audioplayer properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stop unnecessary FFmpeg processes that are running in the background.
+
 ## [2.8.1] - 2024-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Stop unnecessary FFmpeg processes that are running in the background.
+- Audioplayer not stopping properly
 
 ## [2.8.1] - 2024-04-28
 


### PR DESCRIPTION
<!-- A brief description of changes -->
While I migrated muse to play-dl I noticed that the FFmpeg processes that are created when seeking in a video or playing multiple livestreams or non-caching videos will still run and download from YouTube in the background. ~~Now, when a non-caching stream is removed from the player, the corresponding FFmpeg process will also be stopped.~~ Cached streams are still downloaded else the cached audio file will be incomplete.

Edit: Audio player is now stopped properly

- [x] I updated the changelog
