### PR TITLE
Change dependency from 'ytdl-core' to '@distube/ytdl-core'

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "sync-fetch": "^0.3.1",
     "tsx": "3.8.2",
     "xbytes": "^1.7.0",
-    "ytdl-core": "^4.11.5",
+    "@distube/ytdl-core": "^4.13.5",
     "ytsr": "^3.8.4"
   },
   "resolutions": {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -1,7 +1,7 @@
 import {VoiceChannel, Snowflake} from 'discord.js';
 import {Readable} from 'stream';
 import hasha from 'hasha';
-import ytdl, {videoFormat} from 'ytdl-core';
+import ytdl, {videoFormat} from '@distube/ytdl-core';
 import {WriteStream} from 'fs-capacitor';
 import ffmpeg from 'fluent-ffmpeg';
 import shuffle from 'array-shuffle';


### PR DESCRIPTION
This PR resolves https://github.com/codetheweb/muse/issues/1037

Hey! Thanks for your bot, I use it a lot.

https://www.npmjs.com/package/@distube/ytdl-core is a more up-to-date fork of ytdl-core.

It was updated yesterday after breaking changes from Youtube : https://github.com/distubejs/ytdl-core/commit/3df824e57fe4ce3037a91efd124b729dea38c01f

I'm available if you have questions.