### PR TITLE
Use GITHUB_TOKEN for release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,6 +120,8 @@ jobs:
     name: Create GitHub release
     runs-on: ubuntu-latest
     needs: combine
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
 
@@ -145,4 +147,4 @@ jobs:
           prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
           draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
           allowUpdates: true
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- grant the release job `contents: write`
- use the built-in `GITHUB_TOKEN` for `ncipollo/release-action`
- remove the dependency on the stale long-lived `GH_PAT` secret for GitHub release creation

## Why
The `v2.11.3` publish workflow successfully built and published images, but the final GitHub release step failed with `Error 401: Bad credentials` because `GH_PAT` is stale. The release job only needs repository contents write permission, which `GITHUB_TOKEN` can provide directly.

## Validation
- inspected the failed `v2.11.3` workflow run
- verified the release job is the only workflow usage of `GH_PAT`
