### PR TITLE
Harden yt-dlp upgrade flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ SPOTIFY_CLIENT_SECRET=
 # ENABLE_SPONSORBLOCK=true
 # SPONSORBLOCK_TIMEOUT=5    # Delay (in mn) before retrying when SponsorBlock server are unreachable.
 # YT_DLP_PATH=yt-dlp
+# YT_DLP_AUTO_UPDATE=true
 
 # See the README for details on the below variables
 # BOT_STATUS=

--- a/.github/workflows/yt-dlp-refresh.yml
+++ b/.github/workflows/yt-dlp-refresh.yml
@@ -1,0 +1,126 @@
+name: Refresh yt-dlp image
+
+on:
+  schedule:
+    - cron: '17 9 * * *'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to rebuild. Defaults to the latest GitHub release.'
+        required: false
+        type: string
+
+concurrency:
+  group: yt-dlp-refresh-${{ github.event.inputs.release_tag || github.event.release.tag_name || 'latest' }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_IMAGE: ghcr.io/museofficial/muse
+
+jobs:
+  refresh:
+    name: Build image with latest yt-dlp
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Resolve versions
+        id: versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          validate_tag_component() {
+            local name="$1"
+            local value="$2"
+
+            if [[ ! "${value}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "Invalid ${name} for Docker tag: ${value}" >&2
+              exit 1
+            fi
+          }
+
+          release_tag=""
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            release_tag="$(jq -r '.inputs.release_tag // ""' "${GITHUB_EVENT_PATH}")"
+          elif [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            release_tag="$(jq -r '.release.tag_name // ""' "${GITHUB_EVENT_PATH}")"
+          fi
+
+          if [ -z "${release_tag}" ]; then
+            release_tag="$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName --jq .tagName)"
+          fi
+
+          if [ -z "${release_tag}" ]; then
+            echo "Could not resolve a Muse release tag" >&2
+            exit 1
+          fi
+
+          app_version="${release_tag#v}"
+          yt_dlp_version="$(curl -fsSL https://pypi.org/pypi/yt-dlp/json | jq -r '.info.version')"
+          if [ -z "${yt_dlp_version}" ] || [ "${yt_dlp_version}" = "null" ]; then
+            echo "Could not resolve latest yt-dlp version from PyPI" >&2
+            exit 1
+          fi
+
+          validate_tag_component "release tag" "${release_tag}"
+          validate_tag_component "app version" "${app_version}"
+          validate_tag_component "yt-dlp version" "${yt_dlp_version}"
+
+          {
+            echo "release_tag=${release_tag}"
+            echo "app_version=${app_version}"
+            echo "yt_dlp_version=${yt_dlp_version}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "Rebuilding Muse ${release_tag} with yt-dlp ${yt_dlp_version}"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.versions.outputs.release_tag }}
+
+      - name: Build metadata
+        id: build-metadata
+        run: |
+          echo "source_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.REGISTRY_IMAGE }}:yt-dlp-latest
+            ${{ env.REGISTRY_IMAGE }}:yt-dlp-${{ steps.versions.outputs.yt_dlp_version }}
+            ${{ env.REGISTRY_IMAGE }}:${{ steps.versions.outputs.app_version }}-yt-dlp
+            ${{ env.REGISTRY_IMAGE }}:${{ steps.versions.outputs.app_version }}-yt-dlp-${{ steps.versions.outputs.yt_dlp_version }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.build-metadata.outputs.source_sha }}
+            org.opencontainers.image.created=${{ steps.build-metadata.outputs.build_date }}
+            org.opencontainers.image.version=${{ steps.versions.outputs.app_version }}
+            org.opencontainers.image.description=Muse ${{ steps.versions.outputs.app_version }} rebuilt with yt-dlp ${{ steps.versions.outputs.yt_dlp_version }}
+          build-args: |
+            YT_DLP_VERSION=${{ steps.versions.outputs.yt_dlp_version }}
+            COMMIT_HASH=${{ steps.build-metadata.outputs.source_sha }}
+            BUILD_DATE=${{ steps.build-metadata.outputs.build_date }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22-bookworm-slim AS base
 
-ARG YT_DLP_VERSION=2025.10.14
+ARG YT_DLP_VERSION=
+ENV MUSE_BUNDLED_YT_DLP_PATH=/opt/yt-dlp/bin/yt-dlp
 
 # openssl will be a required package if base is updated to 18.16+ due to node:*-slim base distro change
 # https://github.com/prisma/prisma/issues/19729#issuecomment-1591270599
@@ -14,7 +15,11 @@ RUN apt-get update \
     python3 \
     python3-venv \
     && python3 -m venv /opt/yt-dlp \
-    && /opt/yt-dlp/bin/pip install --no-cache-dir "yt-dlp==${YT_DLP_VERSION}" \
+    && if [ -n "${YT_DLP_VERSION}" ]; then \
+        /opt/yt-dlp/bin/pip install --no-cache-dir "yt-dlp==${YT_DLP_VERSION}"; \
+    else \
+        /opt/yt-dlp/bin/pip install --no-cache-dir yt-dlp; \
+    fi \
     && ln -s /opt/yt-dlp/bin/yt-dlp /usr/local/bin/yt-dlp \
     && apt-get autoclean \
     && apt-get autoremove \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There are a variety of image tags available:
 - `:2.1`: versions >= 2.1.0 and < 2.2.0
 - `:2.1.1`: an exact version specifier
 - `:latest`: whatever the latest version is
+- `:yt-dlp-latest`: the latest release rebuilt with the newest available `yt-dlp`
 
 (Replace empty config strings with correct values.)
 
@@ -104,6 +105,10 @@ By default, Muse limits the total cache size to around 2 GB. If you want to chan
 ### yt-dlp
 
 Muse now uses `yt-dlp` to resolve playable YouTube media URLs. In Docker, the image already includes it. For direct Node.js installs, either put `yt-dlp` on your `PATH` or set `YT_DLP_PATH` in your environment file.
+
+Muse logs `YT_DLP_VERSION` on startup. Set `YT_DLP_AUTO_UPDATE=true` to make Muse try to update the configured `yt-dlp` installation before connecting to Discord. This works best with the Docker image's bundled virtualenv, or when `YT_DLP_PATH` points at a virtualenv or standalone `yt-dlp` executable that Muse can update.
+
+The `ghcr.io/museofficial/muse:yt-dlp-latest` image is rebuilt on a schedule from the latest Muse release with the newest `yt-dlp` published to PyPI. Versioned refresh tags are also published as `:<muse-version>-yt-dlp-<yt-dlp-version>`.
 
 ### SponsorBlock
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {TYPES} from './types.js';
 import Bot from './bot.js';
 import Config from './services/config.js';
 import FileCacheProvider from './services/file-cache.js';
+import prepareYtDlp from './utils/prepare-yt-dlp.js';
 
 const bot = container.get<Bot>(TYPES.Bot);
 
@@ -17,6 +18,7 @@ const startBot = async () => {
   await makeDir(path.join(config.CACHE_DIR, 'tmp'));
 
   await container.get<FileCacheProvider>(TYPES.FileCache).cleanup();
+  await prepareYtDlp(config);
 
   await bot.register();
 };

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -9,6 +9,10 @@ dotenv.config({path: process.env.ENV_FILE ?? path.resolve(process.cwd(), '.env')
 
 export const DATA_DIR = path.resolve(process.env.DATA_DIR ? process.env.DATA_DIR : './data');
 
+const firstNonEmpty = (...values: Array<string | undefined>) => values
+  .map(value => value?.trim())
+  .find((value): value is string => Boolean(value));
+
 const CONFIG_MAP = {
   DISCORD_TOKEN: process.env.DISCORD_TOKEN,
   YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
@@ -24,7 +28,8 @@ const CONFIG_MAP = {
   BOT_ACTIVITY: process.env.BOT_ACTIVITY ?? 'music',
   ENABLE_SPONSORBLOCK: process.env.ENABLE_SPONSORBLOCK === 'true',
   SPONSORBLOCK_TIMEOUT: parseInt(process.env.SPONSORBLOCK_TIMEOUT ?? '5', 10),
-  YT_DLP_PATH: process.env.YT_DLP_PATH ?? 'yt-dlp',
+  YT_DLP_PATH: firstNonEmpty(process.env.YT_DLP_PATH, process.env.MUSE_BUNDLED_YT_DLP_PATH) ?? 'yt-dlp',
+  YT_DLP_AUTO_UPDATE: process.env.YT_DLP_AUTO_UPDATE === 'true',
 } as const;
 
 const BOT_ACTIVITY_TYPE_MAP = {
@@ -51,6 +56,7 @@ export default class Config {
   readonly ENABLE_SPONSORBLOCK!: boolean;
   readonly SPONSORBLOCK_TIMEOUT!: number;
   readonly YT_DLP_PATH!: string;
+  readonly YT_DLP_AUTO_UPDATE!: boolean;
 
   constructor() {
     for (const [key, value] of Object.entries(CONFIG_MAP)) {

--- a/src/utils/prepare-yt-dlp.ts
+++ b/src/utils/prepare-yt-dlp.ts
@@ -1,0 +1,44 @@
+import Config from '../services/config.js';
+import {getExecutable, getYtDlpVersion, updateYtDlp} from './yt-dlp.js';
+
+const getErrorMessage = (error: unknown) => error instanceof Error ? error.message : 'unknown error';
+
+const logUnavailableVersion = (error: unknown) => {
+  console.warn(`YT_DLP_VERSION=unavailable (${getExecutable()}: ${getErrorMessage(error)})`);
+};
+
+export default async function prepareYtDlp(config: Config): Promise<void> {
+  if (!config.YT_DLP_AUTO_UPDATE) {
+    try {
+      console.log(`YT_DLP_VERSION=${await getYtDlpVersion()} (${getExecutable()})`);
+    } catch (error: unknown) {
+      logUnavailableVersion(error);
+    }
+
+    return;
+  }
+
+  console.log(`YT_DLP_AUTO_UPDATE=true (${getExecutable()})`);
+
+  const updateResult = await updateYtDlp();
+  if (updateResult.error) {
+    console.warn(`yt-dlp update warning: ${updateResult.error}`);
+  }
+
+  if (!updateResult.afterVersion) {
+    console.warn('YT_DLP_VERSION=unavailable after auto-update');
+    return;
+  }
+
+  if (updateResult.updated && updateResult.beforeVersion) {
+    console.log(`YT_DLP_VERSION=${updateResult.afterVersion} (updated from ${updateResult.beforeVersion})`);
+    return;
+  }
+
+  if (!updateResult.updateSucceeded) {
+    console.log(`YT_DLP_VERSION=${updateResult.afterVersion} (update failed; continuing with installed version)`);
+    return;
+  }
+
+  console.log(`YT_DLP_VERSION=${updateResult.afterVersion} (already current)`);
+}

--- a/src/utils/yt-dlp.ts
+++ b/src/utils/yt-dlp.ts
@@ -1,4 +1,10 @@
 import {execa} from 'execa';
+import {constants as fsConstants, promises as fs} from 'fs';
+import path from 'path';
+
+const YT_DLP_VERSION_TIMEOUT_MS = 15_000;
+const YT_DLP_UPDATE_TIMEOUT_MS = 120_000;
+const YT_DLP_EXTRACT_TIMEOUT_MS = 45_000;
 
 interface YtDlpMediaDownload {
   readonly url?: string;
@@ -6,7 +12,7 @@ interface YtDlpMediaDownload {
   readonly ext?: string;
   readonly acodec?: string;
   readonly vcodec?: string;
-  readonly http_headers?: Record<string, string>;
+  readonly http_headers?: Record<string, string | null | undefined>;
 }
 
 interface YtDlpResponse extends YtDlpMediaDownload {
@@ -21,15 +27,38 @@ export interface YtDlpMediaSource {
   readonly isLive: boolean;
 }
 
-const getExecutable = () => {
-  const configuredPath = process.env.YT_DLP_PATH?.trim();
+export interface YtDlpUpdateResult {
+  readonly beforeVersion: string | null;
+  readonly afterVersion: string | null;
+  readonly updated: boolean;
+  readonly skipped: boolean;
+  readonly updateSucceeded: boolean;
+  readonly error?: string;
+}
 
-  return configuredPath === '' ? 'yt-dlp' : (configuredPath ?? 'yt-dlp');
+const firstNonEmpty = (...values: Array<string | undefined>) => values
+  .map(value => value?.trim())
+  .find((value): value is string => Boolean(value));
+
+export const getExecutable = () => {
+  const configuredPath = firstNonEmpty(process.env.YT_DLP_PATH, process.env.MUSE_BUNDLED_YT_DLP_PATH);
+
+  return configuredPath ?? 'yt-dlp';
 };
 
-const normalizeHeaders = (headers?: Record<string, string>) => {
+const getExecaErrorMessage = (error: unknown) => {
+  if (isExecaError(error)) {
+    const stderr = error.stderr?.trim();
+
+    return stderr ? stderr : (error.shortMessage ?? 'Unknown yt-dlp error');
+  }
+
+  return error instanceof Error ? error.message : 'Unknown yt-dlp error';
+};
+
+const normalizeHeaders = (headers?: Record<string, string | null | undefined>) => {
   const normalizedEntries = Object.entries(headers ?? {})
-    .filter(([, value]) => value !== undefined && value !== '');
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1] !== '');
 
   return Object.fromEntries(normalizedEntries);
 };
@@ -43,6 +72,178 @@ const isExecaError = (error: unknown): error is {stderr?: string; shortMessage?:
 const toYouTubeWatchUrl = (videoIdOrUrl: string) => videoIdOrUrl.length === 11
   ? `https://www.youtube.com/watch?v=${videoIdOrUrl}`
   : videoIdOrUrl;
+
+export const getYtDlpVersion = async (): Promise<string> => {
+  const {stdout} = await execa(getExecutable(), ['--version'], {
+    timeout: YT_DLP_VERSION_TIMEOUT_MS,
+  });
+
+  return stdout.trim();
+};
+
+const pathExists = async (candidatePath: string, mode = fsConstants.F_OK) => {
+  try {
+    await fs.access(candidatePath, mode);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const hasPathSeparator = (candidatePath: string) => candidatePath.includes('/') || candidatePath.includes('\\');
+
+const getCommandCandidates = (command: string) => {
+  if (process.platform !== 'win32' || path.extname(command)) {
+    return [command];
+  }
+
+  const executableExtensions = (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
+    .split(';')
+    .filter(Boolean)
+    .map(extension => `${command}${extension.toLowerCase()}`);
+
+  return [command, ...executableExtensions];
+};
+
+const findExecutableOnPath = async (command: string) => {
+  const directories = (process.env.PATH ?? '')
+    .split(path.delimiter)
+    .filter(Boolean);
+
+  for (const directory of directories) {
+    for (const candidate of getCommandCandidates(command)) {
+      const candidatePath = path.join(directory, candidate);
+      // eslint-disable-next-line no-await-in-loop
+      if (await pathExists(candidatePath, fsConstants.X_OK)) {
+        return candidatePath;
+      }
+    }
+  }
+
+  return null;
+};
+
+const resolveExecutablePath = async () => {
+  const executable = getExecutable();
+
+  if (path.isAbsolute(executable)) {
+    return executable;
+  }
+
+  if (hasPathSeparator(executable)) {
+    return path.resolve(executable);
+  }
+
+  return findExecutableOnPath(executable);
+};
+
+const getPythonExecutableForYtDlp = async () => {
+  const executable = await resolveExecutablePath();
+  if (!executable) {
+    return null;
+  }
+
+  const realExecutable = await fs.realpath(executable);
+  const binDirectory = path.dirname(realExecutable);
+  const pythonExecutable = path.join(binDirectory, process.platform === 'win32' ? 'python.exe' : 'python');
+
+  return (await pathExists(pythonExecutable)) ? pythonExecutable : null;
+};
+
+const updateWithPip = async () => {
+  const pythonExecutable = await getPythonExecutableForYtDlp();
+  if (!pythonExecutable) {
+    return false;
+  }
+
+  await execa(pythonExecutable, [
+    '-m',
+    'pip',
+    'install',
+    '--disable-pip-version-check',
+    '--no-input',
+    '--upgrade',
+    'yt-dlp',
+  ], {
+    env: {
+      PIP_DISABLE_PIP_VERSION_CHECK: '1',
+      PIP_NO_INPUT: '1',
+    },
+    timeout: YT_DLP_UPDATE_TIMEOUT_MS,
+  });
+  return true;
+};
+
+const updateWithYtDlpSelfUpdate = async () => {
+  await execa(getExecutable(), ['-U'], {
+    timeout: YT_DLP_UPDATE_TIMEOUT_MS,
+  });
+  return true;
+};
+
+const joinErrors = (errors: string[]) => errors.length > 0 ? errors.join('; ') : undefined;
+
+export const updateYtDlp = async (): Promise<YtDlpUpdateResult> => {
+  let beforeVersion: string | null = null;
+  try {
+    beforeVersion = await getYtDlpVersion();
+  } catch {
+    // If version probing fails, still try the configured updater below.
+  }
+
+  const errors: string[] = [];
+  let attemptedUpdate = false;
+  let updateSucceeded = false;
+
+  try {
+    const didAttemptUpdate = await updateWithPip();
+    if (didAttemptUpdate) {
+      attemptedUpdate = true;
+      updateSucceeded = true;
+    }
+  } catch (error: unknown) {
+    attemptedUpdate = true;
+    errors.push(getExecaErrorMessage(error));
+  }
+
+  if (!updateSucceeded) {
+    try {
+      await updateWithYtDlpSelfUpdate();
+      attemptedUpdate = true;
+      updateSucceeded = true;
+    } catch (error: unknown) {
+      attemptedUpdate = true;
+      errors.push(getExecaErrorMessage(error));
+    }
+  }
+
+  let afterVersion: string | null = null;
+  try {
+    afterVersion = await getYtDlpVersion();
+  } catch (error: unknown) {
+    const updateErrors = updateSucceeded ? [] : errors;
+
+    return {
+      beforeVersion,
+      afterVersion,
+      updated: false,
+      skipped: !attemptedUpdate,
+      updateSucceeded,
+      error: joinErrors([...updateErrors, getExecaErrorMessage(error)]),
+    };
+  }
+
+  const error = updateSucceeded ? undefined : joinErrors(errors);
+
+  return {
+    beforeVersion,
+    afterVersion,
+    updated: beforeVersion !== null && beforeVersion !== afterVersion,
+    skipped: !attemptedUpdate,
+    updateSucceeded,
+    error,
+  };
+};
 
 export const getYouTubeMediaSource = async (videoIdOrUrl: string): Promise<YtDlpMediaSource> => {
   try {
@@ -59,7 +260,9 @@ export const getYouTubeMediaSource = async (videoIdOrUrl: string): Promise<YtDlp
       '--extractor-args',
       'youtube:player_client=android_vr,default,-ios',
       toYouTubeWatchUrl(videoIdOrUrl),
-    ]);
+    ], {
+      timeout: YT_DLP_EXTRACT_TIMEOUT_MS,
+    });
 
     const response = JSON.parse(stdout) as YtDlpResponse;
     const download = response.requested_downloads?.at(0) ?? response;


### PR DESCRIPTION
## Summary

This hardens Muse's yt-dlp maintenance path so extractor updates can be refreshed without requiring application code changes.

## Changes

- Add `YT_DLP_AUTO_UPDATE=true` startup support for updating the configured yt-dlp installation before connecting to Discord.
- Log the active `YT_DLP_VERSION` on startup without failing startup if yt-dlp is unavailable.
- Install Docker's bundled yt-dlp into a dedicated virtualenv while preserving user-provided `YT_DLP_PATH` overrides.
- Allow Docker builds to install latest yt-dlp by default while still supporting `YT_DLP_VERSION` pinning.
- Resolve PATH-based yt-dlp commands back to their virtualenv for pip upgrades, bound version/update/extraction calls with timeouts, and keep fallback update warnings accurate.
- Add a scheduled/manual/release-triggered workflow that rebuilds the latest Muse release with the newest yt-dlp from PyPI and publishes GHCR tags, including an immutable app+yt-dlp version tag.
- Document the new env var and `:yt-dlp-latest` image tag.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint "src/**/*.{ts,tsx}"`
- `git diff --check`
- Ruby YAML parse for `.github/workflows/yt-dlp-refresh.yml`
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest .github/workflows/yt-dlp-refresh.yml`
- Workflow resolver shell tested for `workflow_dispatch`, `release`, `schedule`, and invalid tag payloads.
- Runtime env precedence probes against compiled `dist` output.
- Fake PATH virtualenv probes for pip update and failed-pip/self-update fallback behavior.
- `docker build -t muse-yt-dlp-runner-test .`
- `docker build --target base --build-arg YT_DLP_VERSION=2026.03.17 -t muse-yt-dlp-pinned-base-test .`
- Docker runtime checks for bundled path, blank `YT_DLP_PATH`, `YT_DLP_PATH=yt-dlp`, `prepareYtDlp`, pinned build arg, and real YouTube media extraction.

Note: the local git pre-commit hook skipped because `yarn` is not installed on this machine; the equivalent checks were run directly through the repo's `node_modules/.bin` tools.
