### PR TITLE
Fix PR image release comments

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -13,8 +13,10 @@ jobs:
     name: Release snapshot and comment in PR
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       packages: write
+      pull-requests: write
       attestations: write
       id-token: write
     steps:
@@ -35,7 +37,7 @@ jobs:
           pattern: image-linux-*
           merge-multiple: true
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load image
         shell: bash
@@ -49,7 +51,7 @@ jobs:
           path: /tmp/SHA
           pattern: sha
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read SHA
         shell: bash
@@ -67,7 +69,7 @@ jobs:
           path: /tmp/metadata
           pattern: metadata
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read the metadata.json file
         id: metadata_reader
@@ -81,7 +83,7 @@ jobs:
           path: /tmp/pull_request_number
           pattern: pull_request_number
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read PR number
         shell: bash
@@ -97,7 +99,7 @@ jobs:
         with:
           header: "pr-release"
           number: ${{ env.PR_NUMBER }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
             #### :package: :robot: A new release has been made for this pull request.
 


### PR DESCRIPTION
## Summary
- Replace stale GH_PAT usage in the PR snapshot release workflow with the built-in GITHUB_TOKEN.
- Add explicit actions: read and pull-requests: write permissions so the workflow can read artifacts from the triggering snapshot run and update the sticky PR comment.

## Root cause
The PR snapshot build still uploads image, metadata, SHA, and PR-number artifacts, but the follow-up workflow no longer has a working GH_PAT. Recent runs either failed with Bad credentials or treated the token as absent, causing actions/download-artifact to find zero artifacts from the triggering workflow run. The job then failed before the sticky pull request comment step.

## Validation
- gh run view confirmed the latest Build snapshot of PR runs succeeded while Release snapshot of PR failed before Create comment.
- gh api confirmed the triggering run had image-linux-amd64, image-linux-arm64, metadata, sha, and pull_request_number artifacts.
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pr-release.yml')"
- git diff --check
