### PR TITLE
Refresh GitHub Actions runtimes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-node@v4
+        - uses: actions/checkout@v6
+        - uses: actions/setup-node@v6
           with:
             node-version: '22'
             cache: 'yarn'

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -21,17 +21,17 @@ jobs:
       id-token: write
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Download images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/images
           pattern: image-linux-*
@@ -46,7 +46,7 @@ jobs:
           docker load -i /tmp/images/image-linux-arm64.tar
 
       - name: Download SHA
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/SHA
           pattern: sha
@@ -64,7 +64,7 @@ jobs:
           docker push ${{ env.REGISTRY_IMAGE }}:${{ env.SHA }}-linux-arm64
 
       - name: Download Docker metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/metadata
           pattern: metadata
@@ -73,12 +73,12 @@ jobs:
 
       - name: Read the metadata.json file
         id: metadata_reader
-        uses: juliangruber/read-file-action@v1.0.0
+        uses: juliangruber/read-file-action@v1.1.8
         with:
           path: /tmp/metadata/metadata/metadata.json
 
       - name: Download PR number
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/pull_request_number
           pattern: pull_request_number
@@ -95,7 +95,7 @@ jobs:
           docker buildx imagetools create $(cat /tmp/metadata/metadata/metadata.json | jq -cr '.tags | map("-t " + .) | join(" ")') ${{ env.REGISTRY_IMAGE }}:${{ env.SHA }}-linux-amd64 ${{ env.REGISTRY_IMAGE }}:${{ env.SHA }}-linux-arm64
 
       - name: Create comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: "pr-release"
           number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/pr-snapshot.yml
+++ b/.github/workflows/pr-snapshot.yml
@@ -27,28 +27,29 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: type=ref,event=pr
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get current time
-        uses: josStorer/get-current-time@v2
         id: current-time
+        shell: bash
+        run: echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Build
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           outputs: type=docker,dest=/tmp/image-${{ env.PLATFORM_PAIR }}.tar
           platforms: ${{ matrix.build-arch }}
@@ -63,7 +64,7 @@ jobs:
         run: echo $DOCKER_METADATA_OUTPUT_JSON > /tmp/metadata.json
 
       - name: Upload metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: metadata
           path: /tmp/metadata.json
@@ -74,14 +75,14 @@ jobs:
           echo "${{ github.sha }}" > /tmp/sha.txt
 
       - name: Upload SHA
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sha
           path: /tmp/sha.txt
           overwrite: true
 
       - name: Upload image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: image-${{ env.PLATFORM_PAIR }}
           path: /tmp/image-${{ env.PLATFORM_PAIR }}.tar
@@ -94,7 +95,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: echo $PR_NUMBER > /tmp/pull_request_number.txt
       - name: Upload PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pull_request_number
           path: /tmp/pull_request_number.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,28 +31,29 @@ jobs:
       id-token: write
     steps:
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get current time
-        uses: josStorer/get-current-time@v2
         id: current-time
+        shell: bash
+        run: echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: |
@@ -73,44 +74,56 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get tags (Docker Hub)
-        id: get-tags-dockerhub
-        uses: Surgo/docker-smart-tag-action@v1
-        with:
-          docker_image: ${{ env.DOCKERHUB_IMAGE }}
-
-      - name: Get tags (ghcr.io)
-        id: get-tags-ghcr
-        uses: Surgo/docker-smart-tag-action@v1
-        with:
-          docker_image: ${{ env.REGISTRY_IMAGE }}
+      - name: Compute release image tags
+        id: image-tags
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          major="${version%%.*}"
+          minor="${version%.*}"
+          dockerhub_tags=(
+            "${DOCKERHUB_IMAGE}:${version}"
+            "${DOCKERHUB_IMAGE}:${minor}"
+            "${DOCKERHUB_IMAGE}:${major}"
+            "${DOCKERHUB_IMAGE}:latest"
+          )
+          ghcr_tags=(
+            "${REGISTRY_IMAGE}:${version}"
+            "${REGISTRY_IMAGE}:${minor}"
+            "${REGISTRY_IMAGE}:${major}"
+            "${REGISTRY_IMAGE}:latest"
+          )
+          {
+            printf 'dockerhub=%s\n' "$(IFS=,; echo "${dockerhub_tags[*]}")"
+            printf 'ghcr=%s\n' "$(IFS=,; echo "${ghcr_tags[*]}")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Combine tags (Docker Hub)
-        run: docker buildx imagetools create $(echo '${{ steps.get-tags-dockerhub.outputs.tag }}' | tr "," "\0" | xargs -0 printf -- '-t %s ') '${{ env.DOCKERHUB_IMAGE }}:${{ github.sha }}-arm64' '${{ env.DOCKERHUB_IMAGE }}:${{ github.sha }}-amd64'
+        run: docker buildx imagetools create $(echo '${{ steps.image-tags.outputs.dockerhub }}' | tr "," "\0" | xargs -0 printf -- '-t %s ') '${{ env.DOCKERHUB_IMAGE }}:${{ github.sha }}-arm64' '${{ env.DOCKERHUB_IMAGE }}:${{ github.sha }}-amd64'
 
       - name: Combine tags (GitHub Container Registry)
-        run: docker buildx imagetools create $(echo '${{ steps.get-tags-ghcr.outputs.tag }}' | tr "," "\0" | xargs -0 printf -- '-t %s ') '${{ env.REGISTRY_IMAGE }}:${{ github.sha }}-arm64' '${{ env.REGISTRY_IMAGE }}:${{ github.sha }}-amd64'
+        run: docker buildx imagetools create $(echo '${{ steps.image-tags.outputs.ghcr }}' | tr "," "\0" | xargs -0 printf -- '-t %s ') '${{ env.REGISTRY_IMAGE }}:${{ github.sha }}-arm64' '${{ env.REGISTRY_IMAGE }}:${{ github.sha }}-amd64'
 
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v2.4.3
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -123,12 +136,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Get version from tag
         id: tag_name
         run: |
-          echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
+          echo "current_version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Get Changelog Entry

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -7,8 +7,8 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-node@v4
+        - uses: actions/checkout@v6
+        - uses: actions/setup-node@v6
           with:
             node-version: '22'
             cache: 'yarn'


### PR DESCRIPTION
## Summary
- Move the PR snapshot/comment workflows and the lint/type-check workflows onto GitHub/Docker actions that publish Node 24 runtimes.
- Replace the current-time helper action with a small UTC shell output step.
- Replace the old Docker smart-tag action in the publish workflow with a shell step that emits the same semver/latest release tags.
- Update Docker Hub description, checkout, setup-node, artifact, Docker, read-file, and sticky-comment actions where Node 24-compatible releases are available.

## Notes
- This intentionally does not replace `.github/workflows/release-comment.yml`; `apexskier/github-release-commenter` still publishes only a Node 20 action, and replacing its release-comment behavior is a larger follow-up than this cleanup.
- `mindsers/changelog-reader-action@v2` also remains because its latest release still uses Node 20 and the current release parsing behavior is more important than rewriting that step in this small PR.

## Validation
- Parsed all workflow YAML with Ruby YAML.load_file.
- Verified the upgraded action tags resolve to action metadata using `runs.using: node24`.
- Ran `git diff --check`.
- Sanity-checked the replacement release tag shell logic for `v2.11.3`.
