### PR TITLE
Refresh yt-dlp workflow actions

### DIFF
--- a/.github/workflows/yt-dlp-refresh.yml
+++ b/.github/workflows/yt-dlp-refresh.yml
@@ -81,7 +81,7 @@ jobs:
 
           echo "Rebuilding Muse ${release_tag} with yt-dlp ${yt_dlp_version}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.versions.outputs.release_tag }}
 
@@ -92,20 +92,20 @@ jobs:
           echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "${GITHUB_OUTPUT}"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
- update the yt-dlp refresh workflow action versions that landed after the initial Node 20 cleanup
- move checkout, QEMU, Buildx, login, and build-push actions to the newer runtime-compatible generations

## Testing
- Parsed all workflow YAML files locally
- Ran git diff --check
- Verified the referenced Docker action tags exist upstream