### PR TITLE
Avoid empty auto-announce after queue ends

### DIFF
--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -663,12 +663,17 @@ export default class {
 
     if (newState.status === AudioPlayerStatus.Idle && this.status === STATUS.PLAYING) {
       await this.forward(1);
+      const currentSong = this.getCurrent();
+      if (!currentSong) {
+        return;
+      }
+
       // Auto announce the next song if configured to
       const settings = await getGuildSettings(this.guildId);
       const {autoAnnounceNextSong} = settings;
       if (autoAnnounceNextSong && this.currentChannel) {
         await this.currentChannel.send({
-          embeds: this.getCurrent() ? [buildPlayingMessageEmbed(this)] : [],
+          embeds: [buildPlayingMessageEmbed(this)],
         });
       }
     }

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -302,21 +302,7 @@ export default class {
       if (this.getCurrent() && this.status !== STATUS.PAUSED) {
         await this.play();
       } else {
-        this.status = STATUS.IDLE;
-        this.audioPlayer?.stop(true);
-
-        const settings = await getGuildSettings(this.guildId);
-
-        const {secondsToWaitAfterQueueEmpties} = settings;
-        if (secondsToWaitAfterQueueEmpties !== 0) {
-          this.disconnectTimer = setTimeout(() => {
-            // Make sure we are not accidentally playing
-            // when disconnecting
-            if (this.status === STATUS.IDLE) {
-              this.disconnect();
-            }
-          }, secondsToWaitAfterQueueEmpties * 1000);
-        }
+        await this.finishQueue();
       }
     } catch (error: unknown) {
       this.queuePosition--;
@@ -662,6 +648,11 @@ export default class {
     }
 
     if (newState.status === AudioPlayerStatus.Idle && this.status === STATUS.PLAYING) {
+      if (!this.canGoForward(1)) {
+        await this.finishQueue();
+        return;
+      }
+
       await this.forward(1);
       const currentSong = this.getCurrent();
       if (!currentSong) {
@@ -676,6 +667,24 @@ export default class {
           embeds: [buildPlayingMessageEmbed(this)],
         });
       }
+    }
+  }
+
+  private async finishQueue(): Promise<void> {
+    this.status = STATUS.IDLE;
+    this.audioPlayer?.stop(true);
+
+    const settings = await getGuildSettings(this.guildId);
+
+    const {secondsToWaitAfterQueueEmpties} = settings;
+    if (secondsToWaitAfterQueueEmpties !== 0) {
+      this.disconnectTimer = setTimeout(() => {
+        // Make sure we are not accidentally playing
+        // when disconnecting
+        if (this.status === STATUS.IDLE) {
+          this.disconnect();
+        }
+      }, secondsToWaitAfterQueueEmpties * 1000);
     }
   }
 


### PR DESCRIPTION
## Summary

Avoid sending an empty auto-announce message when playback reaches the end of the queue.

## Details

When `autoAnnounceNextSong` is enabled, the audio idle handler advances the queue and then announces the next track. If the track that just ended was the final queue item, `getCurrent()` becomes `null`, but Muse still attempted to send an announcement with `embeds: []`. Discord rejects that as an empty message, and the rejection can surface from the async audio event handler.

This returns early when there is no next current song, while preserving the existing announcement behavior when a next track exists.

Related to #1314. This addresses the queue-empty auto-announce case only; it does not change the listener-leave disconnect path.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- focused compiled-code repro for last-song and next-song auto-announce behavior
