### PR TITLE
Handle Spotify autocomplete failures

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -6,7 +6,7 @@ import Spotify from 'spotify-web-api-node';
 import Command from './index.js';
 import {TYPES} from '../types.js';
 import ThirdParty from '../services/third-party.js';
-import getYouTubeAndSpotifySuggestionsFor from '../utils/get-youtube-and-spotify-suggestions-for.js';
+import getYouTubeAndSpotifySuggestionsFor, {SpotifySuggestionsUnavailableError} from '../utils/get-youtube-and-spotify-suggestions-for.js';
 import KeyValueCacheProvider from '../services/key-value-cache.js';
 import {ONE_HOUR_IN_SECONDS} from '../utils/constants.js';
 import AddQueryToQueue from '../services/add-query-to-queue.js';
@@ -81,15 +81,25 @@ export default class implements Command {
       return;
     } catch {}
 
-    const suggestions = await this.cache.wrap(
-      getYouTubeAndSpotifySuggestionsFor,
-      query,
-      this.spotify,
-      10,
-      {
-        expiresIn: ONE_HOUR_IN_SECONDS,
-        key: `autocomplete:${query}`,
-      });
+    let suggestions;
+
+    try {
+      suggestions = await this.cache.wrap(
+        getYouTubeAndSpotifySuggestionsFor,
+        query,
+        this.spotify,
+        10,
+        {
+          expiresIn: ONE_HOUR_IN_SECONDS,
+          key: `autocomplete:${query}`,
+        });
+    } catch (error: unknown) {
+      if (error instanceof SpotifySuggestionsUnavailableError) {
+        suggestions = error.suggestions;
+      } else {
+        throw error;
+      }
+    }
 
     await interaction.respond(suggestions);
   }

--- a/src/services/third-party.ts
+++ b/src/services/third-party.ts
@@ -3,6 +3,7 @@ import SpotifyWebApi from 'spotify-web-api-node';
 import pRetry from 'p-retry';
 import {TYPES} from '../types.js';
 import Config from './config.js';
+import debug from '../utils/debug.js';
 
 @injectable()
 export default class ThirdParty {
@@ -26,10 +27,21 @@ export default class ThirdParty {
   }
 
   private async refreshSpotifyToken() {
-    await pRetry(async () => {
-      const auth = await this.spotify.clientCredentialsGrant();
-      this.spotify.setAccessToken(auth.body.access_token);
-      this.spotifyTokenTimerId = setTimeout(this.refreshSpotifyToken.bind(this), (auth.body.expires_in / 2) * 1000);
-    }, {retries: 5});
+    try {
+      await pRetry(async () => {
+        const auth = await this.spotify.clientCredentialsGrant();
+        this.spotify.setAccessToken(auth.body.access_token);
+        this.scheduleSpotifyTokenRefresh((auth.body.expires_in / 2) * 1000);
+      }, {retries: 5});
+    } catch (error: unknown) {
+      debug('Spotify token refresh failed: %O', error);
+      this.scheduleSpotifyTokenRefresh(60_000);
+    }
+  }
+
+  private scheduleSpotifyTokenRefresh(delay: number) {
+    this.spotifyTokenTimerId = setTimeout(() => {
+      void this.refreshSpotifyToken();
+    }, delay);
   }
 }

--- a/src/utils/get-youtube-and-spotify-suggestions-for.ts
+++ b/src/utils/get-youtube-and-spotify-suggestions-for.ts
@@ -1,6 +1,14 @@
 import {APIApplicationCommandOptionChoice} from 'discord-api-types/v10';
 import SpotifyWebApi from 'spotify-web-api-node';
+import debug from './debug.js';
 import getYouTubeSuggestionsFor from './get-youtube-suggestions-for.js';
+
+export class SpotifySuggestionsUnavailableError extends Error {
+  constructor(public readonly suggestions: APIApplicationCommandOptionChoice[], public readonly originalError: unknown) {
+    super('Spotify autocomplete suggestions failed');
+    this.name = 'SpotifySuggestionsUnavailableError';
+  }
+}
 
 const filterDuplicates = <T extends {name: string}>(items: T[]) => {
   const results: T[] = [];
@@ -18,7 +26,9 @@ const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: Spoti
   // Only search Spotify if enabled
   const spotifySuggestionPromise = spotify === undefined
     ? undefined
-    : spotify.search(query, ['album', 'track'], {limit});
+    : spotify.search(query, ['album', 'track'], {limit})
+      .then(response => ({response}))
+      .catch((error: unknown) => ({error}));
 
   const youtubeSuggestions = await getYouTubeSuggestionsFor(query);
 
@@ -37,7 +47,14 @@ const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: Spoti
       ));
 
   if (spotify !== undefined && spotifySuggestionPromise !== undefined) {
-    const spotifyResponse = (await spotifySuggestionPromise).body;
+    const spotifyResult = await spotifySuggestionPromise;
+
+    if ('error' in spotifyResult) {
+      debug('Spotify autocomplete suggestions failed: %O', spotifyResult.error);
+      throw new SpotifySuggestionsUnavailableError(suggestions, spotifyResult.error);
+    }
+
+    const spotifyResponse = spotifyResult.response.body;
     const spotifyAlbums = filterDuplicates(spotifyResponse.albums?.items ?? []);
     const spotifyTracks = filterDuplicates(spotifyResponse.tracks?.items ?? []);
 


### PR DESCRIPTION
## Summary
- prevent Spotify autocomplete 403s from surfacing as unhandled promise rejections
- return YouTube autocomplete suggestions when Spotify search fails without caching that degraded response
- keep Spotify token refresh failures from terminating the process and retry after a short delay

## Verification
- npm test
- npm run typecheck
- git diff --check
- ~/.codex/skills/autoreview/scripts/autoreview --mode branch --base upstream/master