### PR TITLE
Add /help command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add /help command to list all available commands.
+
 ## [2.11.5] - 2026-06-04
 
 - Fix queue-empty crashes when auto-announce is enabled or playback ends without a next song.

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -53,6 +53,8 @@ export default class {
       }
     }
 
+    this.commandsByName.get('help')?.setCommands?.([...this.commandsByName.values()]);
+
     // Register event handlers
     // eslint-disable-next-line complexity
     this.client.on('interactionCreate', async interaction => {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -17,7 +17,7 @@ export default class implements Command {
 
   public async execute(interaction: ChatInputCommandInteraction): Promise<void> {
     const commandList = this.commands
-      .map(c => `**/${c.slashCommand.name}** — ${c.slashCommand.description}`)
+      .map(c => `**/${c.slashCommand.name ?? ''}** — ${c.slashCommand.description ?? ''}`)
       .join('\n');
 
     await interaction.reply({content: commandList, ephemeral: true});

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,25 @@
+import {ChatInputCommandInteraction} from 'discord.js';
+import {injectable} from 'inversify';
+import Command from './index.js';
+import {SlashCommandBuilder} from '@discordjs/builders';
+
+@injectable()
+export default class implements Command {
+  public readonly slashCommand = new SlashCommandBuilder()
+    .setName('help')
+    .setDescription('shows all available commands');
+
+  private commands: Command[] = [];
+
+  public setCommands(commands: Command[]) {
+    this.commands = commands;
+  }
+
+  public async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const commandList = this.commands
+      .map(c => `**/${c.slashCommand.name}** — ${c.slashCommand.description}`)
+      .join('\n');
+
+    await interaction.reply({content: commandList, ephemeral: true});
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,4 +8,5 @@ export default interface Command {
   execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
   handleButtonInteraction?: (interaction: ButtonInteraction) => Promise<void>;
   handleAutocompleteInteraction?: (interaction: AutocompleteInteraction) => Promise<void>;
+  setCommands?: (commands: Command[]) => void;
 }

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -97,7 +97,7 @@ if (config.SPOTIFY_CLIENT_ID !== '' && config.SPOTIFY_CLIENT_SECRET !== '') {
   Stop,
   Unskip,
   Volume,
-  Help
+  Help,
 ].forEach(command => {
   container.bind<Command>(TYPES.Command).to(command).inSingletonScope();
 });

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -38,6 +38,7 @@ import Skip from './commands/skip.js';
 import Stop from './commands/stop.js';
 import Unskip from './commands/unskip.js';
 import Volume from './commands/volume.js';
+import Help from './commands/help.js';
 import ThirdParty from './services/third-party.js';
 import FileCacheProvider from './services/file-cache.js';
 import KeyValueCacheProvider from './services/key-value-cache.js';
@@ -96,6 +97,7 @@ if (config.SPOTIFY_CLIENT_ID !== '' && config.SPOTIFY_CLIENT_SECRET !== '') {
   Stop,
   Unskip,
   Volume,
+  Help
 ].forEach(command => {
   container.bind<Command>(TYPES.Command).to(command).inSingletonScope();
 });


### PR DESCRIPTION
## Summary

Add a /help slash command that lists all available bot commands and their descriptions.

## Details

The help command is implemented as a standard injectable command following the existing pattern. Since the full command list is only available after the DI container constructs all commands, a `setCommands` method (defined as an optional on the Command interface) is called from `bot.ts` after `commandsByName` is fully built. The response is ephemeral so it is only visible to the user who called it.

This PR is in response to feedback from users on my server trying to ping /help for a list of commands but not being able to see them.

## Validation

- npm run lint
- npm run typecheck
- npm run build
- Deployed locally and verified /help returns an ephemeral list of all commands
- Deployed for testing on my discord server via ghcr.io/brycepollack/muse:latest
- [x] I updated the changelog
