### PR TITLE
Handle Discord voice connection errors

### DIFF
--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -113,6 +113,10 @@ export default class {
     this.currentChannel = channel;
     this.hasRegisteredVoiceActivityListener = false;
 
+    voiceConnection.on('error', error => {
+      console.error(`Voice connection error for guild ${this.guildId}:`, error);
+    });
+
     const guildSettings = await getGuildSettings(this.guildId);
     const stateTransitions = [voiceConnection.state.status];
     voiceConnection.on('stateChange', (oldState, newState) => {


### PR DESCRIPTION
## What changed

Register an `error` listener on every Discord `VoiceConnection` immediately after it is created.

## Why

The pct118 Muse container crashed and restarted after a transient Discord voice WebSocket timeout:

```text
Error: connect ETIMEDOUT 10.0.0.1:2053
Emitted 'error' event on VoiceConnection instance
```

`@discordjs/voice` propagates networking failures through Node's special `error` event. Muse did not subscribe to that event, so Node treated the transient transport failure as fatal before the existing voice disconnect/reconnect state machine could run.

## Impact

Transient Discord voice networking errors are logged with the guild context instead of terminating the entire bot process. Existing state-change, disconnect, and reconnect behavior is unchanged.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Structured autoreview: clean, no actionable findings

After the PR snapshot workflow publishes `ghcr.io/museofficial/muse:pr-<number>`, it will be backed up and canary-tested on the live pct118 Muse container before merge.
