### PR TITLE
Handle unavailable YouTube media safely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ SPOTIFY_CLIENT_SECRET=
 # SPONSORBLOCK_TIMEOUT=5    # Delay (in mn) before retrying when SponsorBlock server are unreachable.
 # YT_DLP_PATH=yt-dlp
 # YT_DLP_AUTO_UPDATE=true
+# YT_DLP_COOKIES_PATH=/run/secrets/youtube-cookies.txt
 
 # See the README for details on the below variables
 # BOT_STATUS=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add optional age-verified YouTube cookie-file support for age-restricted playback.
+- Prevent unavailable YouTube tracks and rejected automatic queue advances from restarting Muse.
+- Install current yt-dlp JavaScript challenge support and use the bundled Node.js runtime.
+
 ## [2.11.5] - 2026-06-04
 
 - Fix queue-empty crashes when auto-announce is enabled or playback ends without a next song.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update \
     python3-venv \
     && python3 -m venv /opt/yt-dlp \
     && if [ -n "${YT_DLP_VERSION}" ]; then \
-        /opt/yt-dlp/bin/pip install --no-cache-dir "yt-dlp==${YT_DLP_VERSION}"; \
+        /opt/yt-dlp/bin/pip install --no-cache-dir "yt-dlp[default]==${YT_DLP_VERSION}"; \
     else \
-        /opt/yt-dlp/bin/pip install --no-cache-dir yt-dlp; \
+        /opt/yt-dlp/bin/pip install --no-cache-dir "yt-dlp[default]"; \
     fi \
     && ln -s /opt/yt-dlp/bin/yt-dlp /usr/local/bin/yt-dlp \
     && apt-get autoclean \

--- a/README.md
+++ b/README.md
@@ -71,11 +71,14 @@ services:
     restart: always
     volumes:
       - ./muse:/data
+      # Optional: mount YouTube-only cookies for age-restricted videos.
+      # - ./youtube-cookies.txt:/run/secrets/youtube-cookies.txt:ro
     environment:
       - DISCORD_TOKEN=
       - YOUTUBE_API_KEY=
       - SPOTIFY_CLIENT_ID=
       - SPOTIFY_CLIENT_SECRET=
+      # - YT_DLP_COOKIES_PATH=/run/secrets/youtube-cookies.txt
 ```
 
 If you keep the same `DISCORD_TOKEN`, reuse the same `/data` volume, and point your Compose service at a newer image tag, Muse will come back up with the same bot identity and persisted database/cache.
@@ -106,6 +109,10 @@ By default, Muse limits the total cache size to around 2 GB. If you want to chan
 Muse now uses `yt-dlp` to resolve playable YouTube media URLs. In Docker, the image already includes it. For direct Node.js installs, either put `yt-dlp` on your `PATH` or set `YT_DLP_PATH` in your environment file.
 
 Muse logs `YT_DLP_VERSION` on startup. Set `YT_DLP_AUTO_UPDATE=true` to make Muse try to update the configured `yt-dlp` installation before connecting to Discord. This works best with the Docker image's bundled virtualenv, or when `YT_DLP_PATH` points at a virtualenv or standalone `yt-dlp` executable that Muse can update.
+
+Age-restricted videos require cookies from an age-verified YouTube account. Export a YouTube-only Netscape cookie file using the [official yt-dlp guidance](https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies), mount it outside `/data`, and set `YT_DLP_COOKIES_PATH` to its container path. Treat this file like a password. Muse copies it to a private per-extraction temporary file because yt-dlp updates the cookie jar while it runs, so the mounted source may remain read-only and concurrent guilds do not share a writable cookie file.
+
+Current YouTube extraction also requires a supported JavaScript runtime. The Docker image includes the matching `yt-dlp-ejs` package and uses its bundled Node.js runtime. Direct installs should install `yt-dlp[default]` and provide Node.js 22 or newer.
 
 The `ghcr.io/museofficial/muse:yt-dlp-latest` image is rebuilt on a schedule from the latest Muse release with the newest `yt-dlp` published to PyPI. Versioned refresh tags are also published as `:<muse-version>-yt-dlp-<yt-dlp-version>`.
 

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -36,6 +36,9 @@ export default class implements Command {
 
     await player.connect(targetVoiceChannel);
     await player.play();
+    if (!player.getCurrent()) {
+      throw new Error('no playable songs found');
+    }
 
     await interaction.reply({
       content: 'the stop-and-go light is now green',

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -83,6 +83,7 @@ export default class AddQueryToQueue {
     const firstSong = newSongs[0];
 
     let statusMsg = '';
+    let shouldShowPlayingEmbed = false;
 
     if (player.voiceConnection === null) {
       await player.connect(targetVoiceChannel);
@@ -94,12 +95,20 @@ export default class AddQueryToQueue {
         statusMsg = 'resuming playback';
       }
 
-      await interaction.editReply({
-        embeds: [buildPlayingMessageEmbed(player)],
-      });
+      shouldShowPlayingEmbed = true;
     } else if (player.status === STATUS.IDLE) {
       // Player is idle, start playback instead
       await player.play();
+    }
+
+    if (!player.getCurrent()) {
+      throw new Error('no playable songs found');
+    }
+
+    if (shouldShowPlayingEmbed) {
+      await interaction.editReply({
+        embeds: [buildPlayingMessageEmbed(player)],
+      });
     }
 
     if (skipCurrentTrack) {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -22,7 +22,7 @@ import FileCacheProvider from './file-cache.js';
 import debug from '../utils/debug.js';
 import {getGuildSettings} from '../utils/get-guild-settings.js';
 import {buildPlayingMessageEmbed} from '../utils/build-embed.js';
-import {getYouTubeMediaSource} from '../utils/yt-dlp.js';
+import {getYouTubeMediaSource, YtDlpMediaUnavailableError} from '../utils/yt-dlp.js';
 import {Setting} from '@prisma/client';
 
 export enum MediaSource {
@@ -270,15 +270,16 @@ export default class {
         this.lastSongURL = currentSong.url;
       }
     } catch (error: unknown) {
-      await this.forward(1);
+      const isGone = typeof error === 'object'
+        && error !== null
+        && 'statusCode' in error
+        && error.statusCode === 410;
 
-      if ((error as {statusCode: number}).statusCode === 410 && currentSong) {
-        const channelId = currentSong.addedInChannelId;
-
-        if (channelId) {
-          debug(`${currentSong.title} is unavailable`);
-          return;
-        }
+      if (error instanceof YtDlpMediaUnavailableError || isGone) {
+        const detail = error instanceof Error ? error.message : 'media returned HTTP 410';
+        console.warn(`Skipping unplayable YouTube track for guild ${this.guildId}: ${detail}`);
+        await this.advancePastUnplayableTrack();
+        return;
       }
 
       throw error;
@@ -582,8 +583,12 @@ export default class {
       return;
     }
 
-    if (this.audioPlayer.listeners('stateChange').length === 0) {
-      this.audioPlayer.on(AudioPlayerStatus.Idle, this.onAudioPlayerIdle.bind(this));
+    if (this.audioPlayer.listeners(AudioPlayerStatus.Idle).length === 0) {
+      this.audioPlayer.on(AudioPlayerStatus.Idle, (oldState, newState) => {
+        void this.onAudioPlayerIdle(oldState, newState).catch(error => {
+          console.error(`Audio player idle handler failed for guild ${this.guildId}:`, error);
+        });
+      });
     }
   }
 
@@ -631,6 +636,17 @@ export default class {
 
   private async waitForVoiceConnectionReady(voiceConnection: VoiceConnection): Promise<void> {
     await entersState(voiceConnection, VoiceConnectionStatus.Ready, 60_000);
+  }
+
+  private async advancePastUnplayableTrack(): Promise<void> {
+    this.manualForward(1);
+
+    if (!this.getCurrent()) {
+      await this.finishQueue();
+      return;
+    }
+
+    await this.play();
   }
 
   private async onAudioPlayerIdle(_oldState: AudioPlayerState, newState: AudioPlayerState): Promise<void> {

--- a/src/utils/yt-dlp.ts
+++ b/src/utils/yt-dlp.ts
@@ -1,5 +1,6 @@
 import {execa} from 'execa';
 import {constants as fsConstants, promises as fs} from 'fs';
+import {tmpdir} from 'os';
 import path from 'path';
 
 const YT_DLP_VERSION_TIMEOUT_MS = 15_000;
@@ -36,9 +37,40 @@ export interface YtDlpUpdateResult {
   readonly error?: string;
 }
 
+export class YtDlpMediaUnavailableError extends Error {}
+
+const isMediaUnavailableError = (detail: string) => [
+  /sign in to confirm your age/i,
+  /this video is not available/i,
+  /video unavailable/i,
+  /private video/i,
+  /video has been removed/i,
+  /members-only content/i,
+].some(pattern => pattern.test(detail));
+
 const firstNonEmpty = (...values: Array<string | undefined>) => values
   .map(value => value?.trim())
   .find((value): value is string => Boolean(value));
+
+const withTemporaryCookies = async <T>(operation: (cookiesPath?: string) => Promise<T>): Promise<T> => {
+  const configuredCookiesPath = firstNonEmpty(process.env.YT_DLP_COOKIES_PATH);
+  if (!configuredCookiesPath) {
+    return operation();
+  }
+
+  const temporaryDirectory = await fs.mkdtemp(path.join(tmpdir(), 'muse-yt-dlp-'));
+  const temporaryCookiesPath = path.join(temporaryDirectory, 'youtube-cookies.txt');
+
+  try {
+    await fs.chmod(temporaryDirectory, 0o700);
+    await fs.copyFile(configuredCookiesPath, temporaryCookiesPath, fsConstants.COPYFILE_EXCL);
+    await fs.chmod(temporaryCookiesPath, 0o600);
+
+    return await operation(temporaryCookiesPath);
+  } finally {
+    await fs.rm(temporaryDirectory, {recursive: true, force: true});
+  }
+};
 
 export const getExecutable = () => {
   const configuredPath = firstNonEmpty(process.env.YT_DLP_PATH, process.env.MUSE_BUNDLED_YT_DLP_PATH);
@@ -163,7 +195,7 @@ const updateWithPip = async () => {
     '--disable-pip-version-check',
     '--no-input',
     '--upgrade',
-    'yt-dlp',
+    'yt-dlp[default]',
   ], {
     env: {
       PIP_DISABLE_PIP_VERSION_CHECK: '1',
@@ -247,39 +279,54 @@ export const updateYtDlp = async (): Promise<YtDlpUpdateResult> => {
 
 export const getYouTubeMediaSource = async (videoIdOrUrl: string): Promise<YtDlpMediaSource> => {
   try {
-    const {stdout} = await execa(getExecutable(), [
-      '--dump-single-json',
-      '--no-playlist',
-      '--skip-download',
-      '--no-warnings',
-      '--no-cache-dir',
-      '-f',
-      'bestaudio/best',
-      '-S',
-      'proto:https',
-      '--extractor-args',
-      'youtube:player_client=android_vr,default,-ios',
-      toYouTubeWatchUrl(videoIdOrUrl),
-    ], {
-      timeout: YT_DLP_EXTRACT_TIMEOUT_MS,
+    return await withTemporaryCookies(async cookiesPath => {
+      const args = [
+        '--dump-single-json',
+        '--no-playlist',
+        '--skip-download',
+        '--no-warnings',
+        '--no-cache-dir',
+        '--js-runtimes',
+        'node',
+        '-f',
+        'bestaudio/best',
+        '-S',
+        'proto:https',
+      ];
+
+      if (cookiesPath) {
+        args.push('--cookies', cookiesPath);
+      }
+
+      args.push(toYouTubeWatchUrl(videoIdOrUrl));
+
+      const {stdout} = await execa(getExecutable(), args, {
+        timeout: YT_DLP_EXTRACT_TIMEOUT_MS,
+      });
+
+      const response = JSON.parse(stdout) as YtDlpResponse;
+      const download = response.requested_downloads?.at(0) ?? response;
+
+      if (!download.url) {
+        throw new Error('yt-dlp did not return a playable media URL.');
+      }
+
+      return {
+        url: download.url,
+        headers: normalizeHeaders(download.http_headers ?? response.http_headers),
+        isLive: Boolean(response.is_live ?? (response.live_status === 'is_live')),
+      };
     });
-
-    const response = JSON.parse(stdout) as YtDlpResponse;
-    const download = response.requested_downloads?.at(0) ?? response;
-
-    if (!download.url) {
-      throw new Error('yt-dlp did not return a playable media URL.');
-    }
-
-    return {
-      url: download.url,
-      headers: normalizeHeaders(download.http_headers ?? response.http_headers),
-      isLive: Boolean(response.is_live ?? (response.live_status === 'is_live')),
-    };
   } catch (error: unknown) {
     if (isExecaError(error)) {
       const detail = error.stderr?.trim() ?? error.shortMessage ?? 'Unknown yt-dlp error';
-      throw new Error(`yt-dlp failed to extract media: ${detail}`);
+      const extractionError = `yt-dlp failed to extract media: ${detail}`;
+
+      if (isMediaUnavailableError(detail)) {
+        throw new YtDlpMediaUnavailableError(extractionError);
+      }
+
+      throw new Error(extractionError);
     }
 
     if (error instanceof SyntaxError) {


### PR DESCRIPTION
## Problem

Muse exits when yt-dlp rejects a queued YouTube track, including age-gated media that returns `Sign in to confirm your age`. The rejected async audio-player idle handler is not contained, so Docker restarts the whole bot.

Observed with video `0sajngb0W6I` using yt-dlp 2026.07.04.

## Fix

- classify known track-specific yt-dlp failures and skip those tracks without crashing the process
- contain async idle-listener rejections while preserving infrastructure failures as real errors
- handle unavailable first, middle, and final tracks without leaving stale embeds or queue state
- add optional `YT_DLP_COOKIES_PATH` support using private per-extraction copies of a read-only canonical cookie file
- install yt-dlp's matching EJS package and explicitly enable the bundled Node runtime

Cookies remain opt-in and are never embedded in the image, repository, logs, or Muse data directory. A dedicated age-verified YouTube account is recommended.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build`
- concurrent cookie-copy smoke: unique mode-0600 temp files, cleanup, canonical file unchanged
- Linux player recovery smoke: unavailable track advances, unavailable tail finishes, infrastructure error propagates, idle rejection is contained
- structured autoreview: clean

After CI publishes the PR image, it will be tested on pct118 before this PR is marked ready or merged.
