### PR TITLE
Fall back to audio for age-restricted videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add optional age-verified YouTube cookie-file support for age-restricted playback.
+- Fall back once to a closely matched audio-focused upload when a music video is age-restricted.
 - Prevent unavailable YouTube tracks and rejected automatic queue advances from restarting Muse.
 - Install current yt-dlp JavaScript challenge support and use the bundled Node.js runtime.
 

--- a/src/managers/player.ts
+++ b/src/managers/player.ts
@@ -2,22 +2,30 @@ import {inject, injectable} from 'inversify';
 import {TYPES} from '../types.js';
 import Player from '../services/player.js';
 import FileCacheProvider from '../services/file-cache.js';
+import type YoutubeAPI from '../services/youtube-api.js';
 
 @injectable()
 export default class {
   private readonly guildPlayers: Map<string, Player>;
   private readonly fileCache: FileCacheProvider;
+  private readonly youtubeAPI: YoutubeAPI;
 
-  constructor(@inject(TYPES.FileCache) fileCache: FileCacheProvider) {
+  constructor(@inject(TYPES.FileCache) fileCache: FileCacheProvider,
+    @inject(TYPES.Services.YoutubeAPI) youtubeAPI: YoutubeAPI) {
     this.guildPlayers = new Map();
     this.fileCache = fileCache;
+    this.youtubeAPI = youtubeAPI;
   }
 
   get(guildId: string): Player {
     let player = this.guildPlayers.get(guildId);
 
     if (!player) {
-      player = new Player(this.fileCache, guildId);
+      player = new Player(
+        this.fileCache,
+        guildId,
+        async song => this.youtubeAPI.findAudioFallback(song),
+      );
 
       this.guildPlayers.set(guildId, player);
     }

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -51,6 +51,8 @@ export interface QueuedSong extends SongMetadata {
   requestedBy: string;
 }
 
+export type AgeRestrictedFallbackResolver = (song: QueuedSong) => Promise<SongMetadata | null>;
+
 export enum STATUS {
   PLAYING,
   PAUSED,
@@ -82,14 +84,16 @@ export default class {
 
   private positionInSeconds = 0;
   private readonly fileCache: FileCacheProvider;
+  private readonly ageRestrictedFallbackResolver?: AgeRestrictedFallbackResolver;
   private disconnectTimer: NodeJS.Timeout | null = null;
 
   private readonly channelToSpeakingUsers: Map<string, Set<string>> = new Map();
   private hasRegisteredVoiceActivityListener = false;
 
-  constructor(fileCache: FileCacheProvider, guildId: string) {
+  constructor(fileCache: FileCacheProvider, guildId: string, ageRestrictedFallbackResolver?: AgeRestrictedFallbackResolver) {
     this.fileCache = fileCache;
     this.guildId = guildId;
+    this.ageRestrictedFallbackResolver = ageRestrictedFallbackResolver;
   }
 
   async connect(channel: VoiceChannel): Promise<void> {
@@ -209,7 +213,7 @@ export default class {
     return this.positionInSeconds;
   }
 
-  async play(): Promise<void> {
+  async play(allowAgeRestrictedFallback = true): Promise<void> {
     const voiceConnection = await this.ensureVoiceConnectionReady();
 
     const currentSong = this.getCurrent();
@@ -274,6 +278,13 @@ export default class {
         && error !== null
         && 'statusCode' in error
         && error.statusCode === 410;
+
+      if (error instanceof YtDlpMediaUnavailableError
+        && error.reason === 'age-restricted'
+        && allowAgeRestrictedFallback
+        && await this.tryAgeRestrictedAudioFallback(currentSong)) {
+        return;
+      }
 
       if (error instanceof YtDlpMediaUnavailableError || isGone) {
         const detail = error instanceof Error ? error.message : 'media returned HTTP 410';
@@ -647,6 +658,49 @@ export default class {
     }
 
     await this.play();
+  }
+
+  private async tryAgeRestrictedAudioFallback(song: QueuedSong): Promise<boolean> {
+    if (!this.ageRestrictedFallbackResolver || song.source !== MediaSource.Youtube) {
+      return false;
+    }
+
+    let fallback: SongMetadata | null;
+    try {
+      fallback = await this.ageRestrictedFallbackResolver(song);
+    } catch {
+      console.warn(`Audio fallback search failed for age-restricted track in guild ${this.guildId}.`);
+      return false;
+    }
+
+    if (this.getCurrent() !== song) {
+      return true;
+    }
+
+    if (!fallback || fallback.source !== MediaSource.Youtube || fallback.url === song.url) {
+      return false;
+    }
+
+    const {queuePosition} = this;
+    const replacement: QueuedSong = {
+      ...fallback,
+      playlist: song.playlist,
+      addedInChannelId: song.addedInChannelId,
+      requestedBy: song.requestedBy,
+    };
+    this.queue[queuePosition] = replacement;
+    console.warn(`Trying audio fallback for age-restricted YouTube track in guild ${this.guildId}: ${song.url} -> ${replacement.url}`);
+
+    try {
+      await this.play(false);
+      return true;
+    } catch (error: unknown) {
+      if (this.queue[queuePosition] === replacement) {
+        this.queue[queuePosition] = song;
+      }
+
+      throw error;
+    }
   }
 
   private async onAudioPlayerIdle(_oldState: AudioPlayerState, newState: AudioPlayerState): Promise<void> {

--- a/src/services/youtube-api.ts
+++ b/src/services/youtube-api.ts
@@ -8,12 +8,16 @@ import KeyValueCacheProvider from './key-value-cache.js';
 import {ONE_HOUR_IN_SECONDS, ONE_MINUTE_IN_SECONDS} from '../utils/constants.js';
 import {parseTime} from '../utils/time.js';
 import getYouTubeID from 'get-youtube-id';
+import {buildAudioFallbackQuery, rankAudioFallbackCandidates} from '../utils/youtube-audio-fallback.js';
 
 interface VideoDetailsResponse {
   id: string;
   contentDetails: {
     videoId: string;
     duration: string;
+    contentRating?: {
+      ytRating?: string;
+    };
   };
   snippet: {
     title: string;
@@ -80,26 +84,7 @@ export default class {
   }
 
   async search(query: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
-    const params = {
-      searchParams: {
-        part: 'snippet',
-        q: query,
-        type: 'video',
-        maxResults: '10',
-      },
-    };
-
-    const {items} = await this.cache.wrap(
-      async () => this.got('search', params).json() as Promise<SearchResponse>,
-      params,
-      {
-        expiresIn: ONE_HOUR_IN_SECONDS,
-      },
-    );
-
-    const ids = items
-      .map(item => item.id.videoId)
-      .filter(Boolean);
+    const ids = await this.searchVideoIDs(query);
 
     if (ids.length === 0) {
       return [];
@@ -113,6 +98,34 @@ export default class {
     return firstVideo
       ? this.getMetadataFromVideo({video: firstVideo, shouldSplitChapters})
       : [];
+  }
+
+  async findAudioFallback(song: SongMetadata): Promise<SongMetadata | null> {
+    if (song.source !== MediaSource.Youtube || song.isLive) {
+      return null;
+    }
+
+    const query = buildAudioFallbackQuery(song);
+    if (!query) {
+      return null;
+    }
+
+    const ids = (await this.searchVideoIDs(query, {videoCategoryId: '10'}))
+      .filter(id => id !== song.url);
+    if (ids.length === 0) {
+      return null;
+    }
+
+    const videos = await this.getVideosByID(ids);
+    const candidates = ids
+      .map(id => videos.find(video => video.id === id))
+      .filter((video): video is VideoDetailsResponse => (
+        Boolean(video)
+        && video!.contentDetails.contentRating?.ytRating !== 'ytAgeRestricted'
+      ))
+      .flatMap(video => this.getMetadataFromVideo({video, shouldSplitChapters: false}));
+
+    return rankAudioFallbackCandidates(song, candidates).at(0) ?? null;
   }
 
   async getVideo(url: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
@@ -296,6 +309,32 @@ export default class {
     }
 
     return map;
+  }
+
+  private async searchVideoIDs(query: string, options: {videoCategoryId?: string} = {}): Promise<string[]> {
+    const searchParams: Record<string, string> = {
+      part: 'snippet',
+      q: query,
+      type: 'video',
+      maxResults: '10',
+    };
+
+    if (options.videoCategoryId) {
+      searchParams.videoCategoryId = options.videoCategoryId;
+    }
+
+    const params = {searchParams};
+    const {items} = await this.cache.wrap(
+      async () => this.got('search', params).json() as Promise<SearchResponse>,
+      params,
+      {
+        expiresIn: ONE_HOUR_IN_SECONDS,
+      },
+    );
+
+    return items
+      .map(item => item.id.videoId)
+      .filter(Boolean);
   }
 
   private async getVideosByID(videoIDs: string[]): Promise<VideoDetailsResponse[]> {

--- a/src/utils/youtube-audio-fallback.ts
+++ b/src/utils/youtube-audio-fallback.ts
@@ -1,0 +1,151 @@
+import type {SongMetadata} from '../services/player.js';
+
+const IGNORED_MATCH_TOKENS = new Set([
+  '4k',
+  'audio',
+  'channel',
+  'hd',
+  'lyrics',
+  'lyric',
+  'music',
+  'official',
+  'records',
+  'recordings',
+  'topic',
+  'vevo',
+  'video',
+  'visualizer',
+]);
+
+const UNWANTED_VERSION_MARKERS = [
+  /\bcover\b/i,
+  /\bextended\b/i,
+  /\binstrumental\b/i,
+  /\bkaraoke\b/i,
+  /\blive\b/i,
+  /\bnightcore\b/i,
+  /\bremix\b/i,
+  /\bslowed\b/i,
+  /\bsped\s+up\b/i,
+];
+
+const GENERIC_CHANNEL_MARKER = /\b(?:channel|entertainment|media|official|records?|recordings?|tv)\b/i;
+
+const cleanVideoTitle = (title: string) => title
+  .replace(/\s*[[(][^\])]*(?:official\s+)?(?:music\s+)?(?:video|audio|lyrics?|visuali[sz]er)[^\])]*[\])]/gi, ' ')
+  .replace(/\b(?:official\s+)?music\s+video\b/gi, ' ')
+  .replace(/\b(?:official\s+)?(?:audio|lyrics?(?:\s+video)?|visuali[sz]er)\b/gi, ' ')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+const matchTokens = (value: string) => Array.from(new Set(value
+  .normalize('NFKD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .toLowerCase()
+  .replace(/&/g, ' and ')
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim()
+  .split(/\s+/)
+  .filter(token => token && !IGNORED_MATCH_TOKENS.has(token))));
+
+const cleanArtist = (artist: string) => artist
+  .replace(/\s+-\s+Topic$/i, '')
+  .replace(/VEVO$/i, '')
+  .trim();
+
+const getReliableArtist = (song: SongMetadata) => {
+  const artist = cleanArtist(song.artist);
+  return artist && !GENERIC_CHANNEL_MARKER.test(artist) ? artist : '';
+};
+
+const requiredTokenOverlap = (tokens: string[]) => tokens.length === 1
+  ? 1
+  : Math.max(2, Math.ceil(tokens.length * 0.6));
+
+const countTokenOverlap = (tokens: string[], candidateTokens: Set<string>) => tokens
+  .filter(token => candidateTokens.has(token))
+  .length;
+
+const hasUnexpectedVersionMarker = (originalTitle: string, candidateTitle: string) => UNWANTED_VERSION_MARKERS
+  .some(pattern => pattern.test(candidateTitle) && !pattern.test(originalTitle));
+
+const isDurationClose = (originalLength: number, candidateLength: number) => {
+  if (originalLength <= 0 || candidateLength <= 0) {
+    return false;
+  }
+
+  const tolerance = Math.max(30, originalLength * 0.25);
+  return Math.abs(originalLength - candidateLength) <= tolerance;
+};
+
+const hasMatchingTitle = (original: SongMetadata, candidate: SongMetadata) => {
+  const originalTokens = matchTokens(cleanVideoTitle(original.title));
+  if (originalTokens.length === 0) {
+    return false;
+  }
+
+  const candidateTokens = new Set(matchTokens(`${candidate.title} ${candidate.artist}`));
+  if (countTokenOverlap(originalTokens, candidateTokens) < requiredTokenOverlap(originalTokens)) {
+    return false;
+  }
+
+  const artistTokens = matchTokens(getReliableArtist(original));
+  const originalTitleTokens = new Set(originalTokens);
+  const titleIncludesArtist = artistTokens.length > 0
+    && countTokenOverlap(artistTokens, originalTitleTokens) >= requiredTokenOverlap(artistTokens);
+
+  if (!titleIncludesArtist && artistTokens.length > 0) {
+    return countTokenOverlap(artistTokens, candidateTokens) >= requiredTokenOverlap(artistTokens);
+  }
+
+  return originalTokens.length > 2 || artistTokens.length > 0;
+};
+
+const preferenceScore = (original: SongMetadata, candidate: SongMetadata) => {
+  let score = 0;
+  if (/\s-\sTopic$/i.test(candidate.artist)) {
+    score += 4;
+  }
+
+  if (/\b(?:official\s+)?audio\b|\blyrics?\b/i.test(candidate.title)) {
+    score += 2;
+  }
+
+  const durationTolerance = Math.max(30, original.length * 0.25);
+  score += 1 - (Math.abs(original.length - candidate.length) / durationTolerance);
+  return score;
+};
+
+export const buildAudioFallbackQuery = (song: SongMetadata) => {
+  const title = cleanVideoTitle(song.title);
+  if (!title) {
+    return '';
+  }
+
+  const titleTokens = new Set(matchTokens(title));
+  const artist = getReliableArtist(song);
+  const artistTokens = matchTokens(artist);
+  const titleIncludesArtist = artistTokens.length > 0
+    && countTokenOverlap(artistTokens, titleTokens) >= requiredTokenOverlap(artistTokens);
+
+  if (artistTokens.length === 0 && titleTokens.size <= 2) {
+    return '';
+  }
+
+  return `${titleIncludesArtist || !artist ? '' : `${artist} `}${title} audio Topic`;
+};
+
+export const rankAudioFallbackCandidates = (original: SongMetadata, candidates: SongMetadata[]) => candidates
+  .map((candidate, index) => ({candidate, index}))
+  .filter(({candidate}) => (
+    candidate.url !== original.url
+    && !candidate.isLive
+    && isDurationClose(original.length, candidate.length)
+    && !hasUnexpectedVersionMarker(cleanVideoTitle(original.title), candidate.title)
+    && hasMatchingTitle(original, candidate)
+  ))
+  .sort((left, right) => (
+    preferenceScore(original, right.candidate) - preferenceScore(original, left.candidate)
+    || left.index - right.index
+  ))
+  .map(({candidate}) => candidate);

--- a/src/utils/yt-dlp.ts
+++ b/src/utils/yt-dlp.ts
@@ -37,16 +37,33 @@ export interface YtDlpUpdateResult {
   readonly error?: string;
 }
 
-export class YtDlpMediaUnavailableError extends Error {}
+export type YtDlpMediaUnavailableReason = 'age-restricted' | 'unavailable';
 
-const isMediaUnavailableError = (detail: string) => [
-  /sign in to confirm your age/i,
-  /this video is not available/i,
-  /video unavailable/i,
-  /private video/i,
-  /video has been removed/i,
-  /members-only content/i,
-].some(pattern => pattern.test(detail));
+export class YtDlpMediaUnavailableError extends Error {
+  readonly reason: YtDlpMediaUnavailableReason;
+
+  constructor(message: string, reason: YtDlpMediaUnavailableReason = 'unavailable') {
+    super(message);
+    this.name = 'YtDlpMediaUnavailableError';
+    this.reason = reason;
+  }
+}
+
+const getMediaUnavailableReason = (detail: string): YtDlpMediaUnavailableReason | null => {
+  if (/sign in to confirm your age/i.test(detail)) {
+    return 'age-restricted';
+  }
+
+  return [
+    /this video is not available/i,
+    /video unavailable/i,
+    /private video/i,
+    /video has been removed/i,
+    /members-only content/i,
+  ].some(pattern => pattern.test(detail))
+    ? 'unavailable'
+    : null;
+};
 
 const firstNonEmpty = (...values: Array<string | undefined>) => values
   .map(value => value?.trim())
@@ -322,8 +339,9 @@ export const getYouTubeMediaSource = async (videoIdOrUrl: string): Promise<YtDlp
       const detail = error.stderr?.trim() ?? error.shortMessage ?? 'Unknown yt-dlp error';
       const extractionError = `yt-dlp failed to extract media: ${detail}`;
 
-      if (isMediaUnavailableError(detail)) {
-        throw new YtDlpMediaUnavailableError(extractionError);
+      const unavailableReason = getMediaUnavailableReason(detail);
+      if (unavailableReason) {
+        throw new YtDlpMediaUnavailableError(extractionError, unavailableReason);
       }
 
       throw new Error(extractionError);


### PR DESCRIPTION
## Problem

An age-gated YouTube music video is now skipped safely, but Muse can often continue playing the requested song by selecting an audio-only upload instead.

The production incident was `0sajngb0W6I` (`Paul Hardcastle - 19 (Official Music Video)`, 3:42). A normalized music search resolves the playable Topic upload `9m2dMZdH0k8` (`19`, 3:31).

## Change

- distinguish age-confirmation failures from private, removed, members-only, and generic unavailable media
- run one music-category search using a cleaned title plus `audio Topic`
- reject the original ID, live/age-rated results, materially different durations, covers/remixes/extended variants, and candidates without sufficient title/artist evidence
- prefer Topic and audio-labelled candidates
- replace the current queue item while preserving requester and playlist context, then retry once without recursive fallback
- retain safe skip behavior when search fails or no credible candidate exists
- continue surfacing real extractor/infrastructure failures

Short or generic titles require a trustworthy artist-channel match. Label channels such as `Chrysalis Records` are not treated as artists.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build`
- deterministic Linux compiled-code matrix covering success, same-ID rejection, wrong-artist rejection, bounded retry, fallback exhaustion, private media, search outage, and infrastructure failures
- real YouTube API search selected `9m2dMZdH0k8`
- real yt-dlp extraction started that fallback for the exact production incident
- structured autoreview: clean after resolving its wrong-artist finding

After CI publishes the immutable PR image, it will be deployed and exercised on pct118 before this PR is marked ready or merged.
