### PR TITLE
Fix playback reliability and add behavior coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,16 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Test
+    name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['22.12.0', '22']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Generate Prisma client
+        run: yarn prisma generate
+      - name: Run tests
+        run: yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fall back once to a closely matched audio-focused upload when a music video is age-restricted.
 - Prevent unavailable YouTube tracks and rejected automatic queue advances from restarting Muse.
 - Install current yt-dlp JavaScript challenge support and use the bundled Node.js runtime.
+- Fix provider routing, playlist limits and pagination, and YouTube chapter parsing.
+- Fix queue command boundaries, queue insertion, and Player state transitions.
+- Correct SponsorBlock trimming and restore pre-duck volume after overlapping speakers finish.
+- Make cache writes safe under concurrent downloads and reject negative cache limits.
+- Add a Node.js behavior suite for commands, providers, queueing, playback, and caching.
 
 ## [2.11.5] - 2026-06-04
 
@@ -399,6 +404,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [unreleased]: https://github.com/museofficial/muse/compare/v2.11.5...HEAD
 [2.11.5]: https://github.com/museofficial/muse/compare/v2.11.4...v2.11.5
 [2.11.4]: https://github.com/museofficial/muse/compare/v2.11.3...v2.11.4
+[2.11.3]: https://github.com/museofficial/muse/compare/v2.11.2...v2.11.3
+[2.11.2]: https://github.com/museofficial/muse/compare/v2.11.1...v2.11.2
 [2.11.1]: https://github.com/museofficial/muse/compare/v2.11.0...v2.11.1
 [2.11.0]: https://github.com/museofficial/muse/compare/v2.10.1...v2.11.0
 [2.10.1]: https://github.com/museofficial/muse/compare/v2.10.0...v2.10.1
@@ -472,5 +479,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/codetheweb/muse/releases/tag/v0.2.0
 [0.1.1]: https://github.com/codetheweb/muse/releases/tag/v0.1.1
 [0.1.0]: https://github.com/codetheweb/muse/releases/tag/v0.1.0
-
-[2.11.3]: https://github.com/museofficial/muse/compare/v2.11.1...v2.11.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fall back once to a closely matched audio-focused upload when a music video is age-restricted.
 - Prevent unavailable YouTube tracks and rejected automatic queue advances from restarting Muse.
 - Install current yt-dlp JavaScript challenge support and use the bundled Node.js runtime.
-- Fix provider routing, playlist limits and pagination, and YouTube chapter parsing.
-- Fix queue command boundaries, queue insertion, and Player state transitions.
+- Fix provider routing and autocomplete allocation, playlist limits and pagination, and YouTube chapter parsing.
+- Fix queue command boundaries, queue insertion, and concurrent Player playback and voice-recovery transitions.
 - Correct SponsorBlock trimming and restore pre-duck volume after overlapping speakers finish.
-- Make cache writes safe under concurrent downloads and reject negative cache limits.
+- Make cache writes safe under concurrent downloads, reconcile every indexed row, and reject negative cache limits.
+- Reject blank required credentials and honor explicit SQLite database paths during legacy migrations.
 - Add a Node.js behavior suite for commands, providers, queueing, playback, and caching.
 
 ## [2.11.5] - 2026-06-04

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ If you keep the same `DISCORD_TOKEN`, reuse the same `/data` volume, and point y
 
 **Note**: if you're on Windows, you may need to manually set the ffmpeg path. See [#345](https://github.com/museofficial/muse/issues/345) for details.
 
+### Local validation
+
+Run the behavior suite locally with:
+
+```bash
+npm test
+```
+
 ## ⚙️ Additional configuration (advanced)
 
 ### Cache
@@ -163,4 +171,4 @@ You can configure the bot to automatically turn down the volume when people are 
 
 - `/config set-reduce-vol-when-voice true` - Enable automatic volume reduction
 - `/config set-reduce-vol-when-voice false` - Disable automatic volume reduction
-- `/config set-reduce-vol-when-voice-target <volume>` - Set the target volume percentage when people speak (0-100, default is 70)
+- `/config set-reduce-vol-when-voice-target <volume>` - Set the target volume percentage when people speak (0-100, default is 20)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "typecheck": "tsc --noEmit",
-    "test": "npm run lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "start": "npm run env:set-database-url -- tsx src/scripts/migrate-and-start.ts",
     "cache:clear-key-value": "npm run env:set-database-url tsx src/scripts/cache-clear-key-value.ts",
     "dev": "npm run env:set-database-url -- tsx watch src/scripts/start.ts",
@@ -53,7 +54,8 @@
     "prisma": "5.21.1",
     "release-it": "^14.11.8",
     "type-fest": "^2.12.0",
-    "typescript": "^4.6.4"
+    "typescript": "^4.6.4",
+    "vitest": "4.1.10"
   },
   "eslintConfig": {
     "extends": [
@@ -81,7 +83,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm test"
+      "pre-commit": "npm run lint && npm test"
     }
   },
   "dependencies": {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -259,10 +259,11 @@ export default class implements Command {
             : `${config.secondsToWaitAfterQueueEmpties}s`,
           'Leave if there are no listeners': config.leaveIfNoListeners ? 'yes' : 'no',
           'Auto announce next song in queue': config.autoAnnounceNextSong ? 'yes' : 'no',
-          'Add to queue reponses show for requester only': config.autoAnnounceNextSong ? 'yes' : 'no',
+          'Add to queue reponses show for requester only': config.queueAddResponseEphemeral ? 'yes' : 'no',
           'Default Volume': config.defaultVolume,
           'Default queue page size': config.defaultQueuePageSize,
           'Reduce volume when people speak': config.turnDownVolumeWhenPeopleSpeak ? 'yes' : 'no',
+          'Reduce volume when people speak target': config.turnDownVolumeWhenPeopleSpeakTarget,
         };
 
         let description = '';

--- a/src/commands/fseek.ts
+++ b/src/commands/fseek.ts
@@ -46,6 +46,10 @@ export default class implements Command {
 
     const seekTime = durationStringToSeconds(seekValue);
 
+    if (!Number.isFinite(seekTime) || seekTime <= 0) {
+      throw new Error('invalid seek value');
+    }
+
     if (seekTime + player.getPosition() > currentSong.length) {
       throw new Error('can\'t seek past the end of the song');
     }

--- a/src/commands/loop-queue.ts
+++ b/src/commands/loop-queue.ts
@@ -27,7 +27,7 @@ export default class implements Command {
       throw new Error('no songs to loop!');
     }
 
-    if (player.queueSize() < 2) {
+    if (player.queueSize() < 1) {
       throw new Error('not enough songs to loop a queue!');
     }
 

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -73,13 +73,16 @@ export default class implements Command {
       return;
     }
 
+    let queryProtocol: string | undefined;
     try {
-      // Don't return suggestions for URLs
-      // eslint-disable-next-line no-new
-      new URL(query);
+      queryProtocol = new URL(query).protocol;
+    } catch {}
+
+    // Don't return suggestions for supported provider URLs
+    if (queryProtocol && ['http:', 'https:', 'spotify:'].includes(queryProtocol)) {
       await interaction.respond([]);
       return;
-    } catch {}
+    }
 
     let suggestions;
 

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -15,6 +15,7 @@ export default class implements Command {
     .addIntegerOption(option => option
       .setName('page')
       .setDescription('page of queue to show [default: 1]')
+      .setMinValue(1)
       .setRequired(false))
     .addIntegerOption(option => option
       .setName('page-size')

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -13,11 +13,13 @@ export default class implements Command {
     .addIntegerOption(option =>
       option.setName('position')
         .setDescription('position of the song to remove [default: 1]')
+        .setMinValue(1)
         .setRequired(false),
     )
     .addIntegerOption(option =>
       option.setName('range')
         .setDescription('number of songs to remove [default: 1]')
+        .setMinValue(1)
         .setRequired(false));
 
   private readonly playerManager: PlayerManager;
@@ -38,6 +40,10 @@ export default class implements Command {
 
     if (range < 1) {
       throw new Error('range must be at least 1');
+    }
+
+    if (position > player.queueSize()) {
+      throw new Error('position is outside the range of the queue');
     }
 
     player.removeFromQueue(position, range);

--- a/src/commands/seek.ts
+++ b/src/commands/seek.ts
@@ -44,7 +44,7 @@ export default class implements Command {
     let seekTime = 0;
 
     if (time.includes(':')) {
-      if (!/^[+-]?\d+(?::\d+)+$/.test(time)) {
+      if (!/^\+?\d+(?::\d+)+$/.test(time)) {
         throw new Error('invalid seek value');
       }
 

--- a/src/commands/seek.ts
+++ b/src/commands/seek.ts
@@ -44,7 +44,7 @@ export default class implements Command {
     let seekTime = 0;
 
     if (time.includes(':')) {
-      if (!/^-?\d+(?::\d+)+$/.test(time)) {
+      if (!/^[+-]?\d+(?::\d+)+$/.test(time)) {
         throw new Error('invalid seek value');
       }
 

--- a/src/commands/seek.ts
+++ b/src/commands/seek.ts
@@ -39,14 +39,22 @@ export default class implements Command {
       throw new Error('can\'t seek in a livestream');
     }
 
-    const time = interaction.options.getString('time')!;
+    const time = interaction.options.getString('time')!.trim();
 
     let seekTime = 0;
 
     if (time.includes(':')) {
+      if (!/^-?\d+(?::\d+)+$/.test(time)) {
+        throw new Error('invalid seek value');
+      }
+
       seekTime = parseTime(time);
     } else {
       seekTime = durationStringToSeconds(time);
+    }
+
+    if (!Number.isFinite(seekTime) || seekTime < 0) {
+      throw new Error('invalid seek value');
     }
 
     if (seekTime > currentSong.length) {

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -3,7 +3,6 @@ import {SlashCommandBuilder} from '@discordjs/builders';
 import {TYPES} from '../types.js';
 import {inject, injectable} from 'inversify';
 import PlayerManager from '../managers/player.js';
-import {STATUS} from '../services/player.js';
 import Command from './index.js';
 
 @injectable()
@@ -25,10 +24,6 @@ export default class implements Command {
 
     if (!player.voiceConnection) {
       throw new Error('not connected');
-    }
-
-    if (player.status !== STATUS.PLAYING) {
-      throw new Error('not currently playing');
     }
 
     player.stop();

--- a/src/scripts/migrate-and-start.ts
+++ b/src/scripts/migrate-and-start.ts
@@ -6,10 +6,12 @@ import Prisma from '@prisma/client';
 import ora from 'ora';
 import {startBot} from '../index.js';
 import logBanner from '../utils/log-banner.js';
-import createDatabaseUrl, {createDatabasePath} from '../utils/create-database-url.js';
+import createDatabaseUrl, {createDatabasePathFromUrl} from '../utils/create-database-url.js';
 import {DATA_DIR} from '../services/config.js';
+import {runMigrationsAndStart} from '../utils/run-migrations-and-start.js';
 
-process.env.DATABASE_URL = process.env.DATABASE_URL ?? createDatabaseUrl(DATA_DIR);
+const databaseUrl = process.env.DATABASE_URL ?? createDatabaseUrl(DATA_DIR);
+process.env.DATABASE_URL = databaseUrl;
 
 const migrateFromSequelizeToPrisma = async () => {
   await execa('prisma', ['migrate', 'resolve', '--applied', '20220101155430_migrate_from_sequelize'], {preferLocal: true});
@@ -17,7 +19,7 @@ const migrateFromSequelizeToPrisma = async () => {
 
 const doesUserHaveExistingDatabase = async () => {
   try {
-    await fs.access(createDatabasePath(DATA_DIR));
+    await fs.access(createDatabasePathFromUrl(databaseUrl));
 
     return true;
   } catch {
@@ -51,8 +53,10 @@ const hasDatabaseBeenMigratedToPrisma = async () => {
 
   const spinner = ora('Applying database migrations...').start();
 
-  if (await doesUserHaveExistingDatabase()) {
-    if (!(await hasDatabaseBeenMigratedToPrisma())) {
+  await runMigrationsAndStart({
+    databaseExists: doesUserHaveExistingDatabase,
+    hasPrismaMigrations: hasDatabaseBeenMigratedToPrisma,
+    resolveInitialMigration: async () => {
       try {
         await migrateFromSequelizeToPrisma();
       } catch (error) {
@@ -64,22 +68,21 @@ const hasDatabaseBeenMigratedToPrisma = async () => {
           throw error;
         }
       }
-    }
-  }
-
-  try {
-    await execa('prisma', ['migrate', 'deploy'], {preferLocal: true});
-  } catch (error: unknown) {
-    if ((error as ExecaError).stderr) {
-      spinner.fail('Failed to apply database migrations:');
-      console.error((error as ExecaError).stderr);
-      process.exit(1);
-    } else {
-      throw error;
-    }
-  }
-
-  spinner.succeed('Database migrations applied.');
-
-  await startBot();
+    },
+    deployMigrations: async () => {
+      try {
+        await execa('prisma', ['migrate', 'deploy'], {preferLocal: true});
+      } catch (error: unknown) {
+        if ((error as ExecaError).stderr) {
+          spinner.fail('Failed to apply database migrations:');
+          console.error((error as ExecaError).stderr);
+          process.exit(1);
+        } else {
+          throw error;
+        }
+      }
+    },
+    migrationsApplied: () => spinner.succeed('Database migrations applied.'),
+    startBot,
+  });
 })();

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -13,6 +13,10 @@ import Config from './config.js';
 import KeyValueCacheProvider from './key-value-cache.js';
 import {ONE_HOUR_IN_SECONDS} from '../utils/constants.js';
 
+const isSameQueueEntry = (capturedId: number | null, currentId: number | null) => (
+  capturedId !== null && capturedId === currentId
+);
+
 @injectable()
 export default class AddQueryToQueue {
   private readonly sponsorBlock?: SponsorBlock;
@@ -48,7 +52,8 @@ export default class AddQueryToQueue {
   }): Promise<void> {
     const guildId = interaction.guild!.id;
     const player = this.playerManager.get(guildId);
-    const wasPlayingSong = player.getCurrent() !== null;
+    const currentQueueEntryId = player.getCurrentQueueEntryId();
+    const wasPlayingSong = currentQueueEntryId !== null;
 
     const [targetVoiceChannel] = getMemberVoiceChannel(interaction.member as GuildMember) ?? getMostPopularVoiceChannel(interaction.guild!);
 
@@ -115,7 +120,7 @@ export default class AddQueryToQueue {
     }
 
     let didSkipCurrentTrack = false;
-    if (skipCurrentTrack && wasPlayingSong) {
+    if (skipCurrentTrack && isSameQueueEntry(currentQueueEntryId, player.getCurrentQueueEntryId())) {
       try {
         await player.forward(1);
         didSkipCurrentTrack = true;

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -72,12 +72,15 @@ export default class AddQueryToQueue {
       newSongs = await Promise.all(newSongs.map(this.skipNonMusicSegments.bind(this)));
     }
 
-    newSongs.forEach(song => {
+    newSongs.forEach((song, index) => {
       player.add({
         ...song,
         addedInChannelId: interaction.channel!.id,
         requestedBy: interaction.member!.user.id,
-      }, {immediate: addToFrontOfQueue ?? false});
+      }, {
+        immediate: addToFrontOfQueue ?? false,
+        immediateOffset: index,
+      });
     });
 
     const firstSong = newSongs[0];
@@ -111,9 +114,11 @@ export default class AddQueryToQueue {
       });
     }
 
-    if (skipCurrentTrack) {
+    let didSkipCurrentTrack = false;
+    if (skipCurrentTrack && wasPlayingSong) {
       try {
         await player.forward(1);
+        didSkipCurrentTrack = true;
       } catch (_: unknown) {
         throw new Error('no song to skip to');
       }
@@ -133,9 +138,9 @@ export default class AddQueryToQueue {
     }
 
     if (newSongs.length === 1) {
-      await interaction.editReply(`u betcha, **${firstSong.title}** added to the${addToFrontOfQueue ? ' front of the' : ''} queue${skipCurrentTrack ? 'and current track skipped' : ''}${extraMsg}`);
+      await interaction.editReply(`u betcha, **${firstSong.title}** added to the${addToFrontOfQueue ? ' front of the' : ''} queue${didSkipCurrentTrack ? ' and current track skipped' : ''}${extraMsg}`);
     } else {
-      await interaction.editReply(`u betcha, **${firstSong.title}** and ${newSongs.length - 1} other songs were added to the queue${skipCurrentTrack ? 'and current track skipped' : ''}${extraMsg}`);
+      await interaction.editReply(`u betcha, **${firstSong.title}** and ${newSongs.length - 1} other songs were added to the queue${didSkipCurrentTrack ? ' and current track skipped' : ''}${extraMsg}`);
     }
   }
 
@@ -161,7 +166,7 @@ export default class AddQueryToQueue {
           const previousSegment = acc[acc.length - 1];
           // If segments overlap merge
           if (previousSegment && previousSegment.endTime > startTime) {
-            acc[acc.length - 1].endTime = endTime;
+            acc[acc.length - 1].endTime = Math.max(previousSegment.endTime, endTime);
           } else {
             acc.push({startTime, endTime});
           }
@@ -171,14 +176,18 @@ export default class AddQueryToQueue {
 
       const intro = skipSegments[0];
       const outro = skipSegments.at(-1);
-      if (outro && outro?.endTime >= song.length - 2) {
-        song.length -= outro.endTime - outro.startTime;
+      const shouldTrimIntro = intro && intro.startTime <= 2;
+      const shouldTrimOutro = outro && outro.endTime >= song.length - 2;
+      if (shouldTrimOutro && (!shouldTrimIntro || outro !== intro)) {
+        song.length -= Math.max(0, outro.endTime - outro.startTime);
       }
 
-      if (intro?.startTime <= 2) {
-        song.offset = Math.floor(intro.endTime);
+      if (shouldTrimIntro) {
+        song.offset = Math.max(0, Math.floor(intro.endTime));
         song.length -= song.offset;
       }
+
+      song.length = Math.max(0, song.length);
 
       return song;
     } catch (e) {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -14,8 +14,8 @@ const firstNonEmpty = (...values: Array<string | undefined>) => values
   .find((value): value is string => Boolean(value));
 
 const CONFIG_MAP = {
-  DISCORD_TOKEN: process.env.DISCORD_TOKEN,
-  YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
+  DISCORD_TOKEN: firstNonEmpty(process.env.DISCORD_TOKEN),
+  YOUTUBE_API_KEY: firstNonEmpty(process.env.YOUTUBE_API_KEY),
   SPOTIFY_CLIENT_ID: process.env.SPOTIFY_CLIENT_ID ?? '',
   SPOTIFY_CLIENT_SECRET: process.env.SPOTIFY_CLIENT_SECRET ?? '',
   REGISTER_COMMANDS_ON_BOT: process.env.REGISTER_COMMANDS_ON_BOT === 'true',

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -75,6 +75,10 @@ export default class Config {
           throw new Error(`Invalid numeric value for ${key}`);
         }
 
+        if (key === 'CACHE_LIMIT_IN_BYTES' && value < 0) {
+          throw new Error('Invalid numeric value for CACHE_LIMIT_IN_BYTES: value must be non-negative');
+        }
+
         this[key as ConditionalKeys<typeof CONFIG_MAP, number>] = value;
       } else if (typeof value === 'string') {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/src/services/file-cache.ts
+++ b/src/services/file-cache.ts
@@ -71,9 +71,27 @@ export default class FileCacheProvider {
     const finalPath = path.join(this.config.CACHE_DIR, hash);
 
     const stream = createWriteStream(tmpPath);
+    let finished = false;
+    let writeFailed = false;
+
+    const handleWriteError = (error: unknown) => {
+      writeFailed = true;
+      this.reportWriteError(error);
+    };
+
+    stream.once('finish', () => {
+      finished = true;
+    });
+    stream.once('error', handleWriteError);
 
     stream.once('close', () => {
-      void this.finalizeWrite(hash, tmpPath, finalPath)
+      stream.removeListener('error', handleWriteError);
+
+      const completion = finished && !writeFailed
+        ? this.finalizeWrite(hash, tmpPath, finalPath)
+        : this.removeTemporaryFile(tmpPath);
+
+      void completion
         .catch(error => {
           this.reportFinalizationError(stream, error);
         });
@@ -171,6 +189,12 @@ export default class FileCacheProvider {
     }
   }
 
+  private reportWriteError(error: unknown) {
+    const writeError = error instanceof Error ? error : new Error(String(error));
+    console.error('Failed to write cache temporary file:', writeError);
+    debug(`Failed to write cache temporary file: ${writeError.message}`);
+  }
+
   private async evictOldest() {
     debug('Evicting oldest files...');
 
@@ -211,6 +235,15 @@ export default class FileCacheProvider {
   }
 
   private async removeOrphans() {
+    const temporaryDirectory = path.join(this.config.CACHE_DIR, 'tmp');
+
+    for await (const dirent of await fs.opendir(temporaryDirectory)) {
+      if (dirent.isFile()) {
+        debug(`${dirent.name} was abandoned in the cache temporary directory. Removing from disk.`);
+        await fs.unlink(path.join(temporaryDirectory, dirent.name));
+      }
+    }
+
     // Check filesystem direction (do files exist on the disk but not in the database?)
     for await (const dirent of await fs.opendir(this.config.CACHE_DIR)) {
       if (dirent.isFile()) {

--- a/src/services/file-cache.ts
+++ b/src/services/file-cache.ts
@@ -1,4 +1,5 @@
-import {promises as fs, createWriteStream} from 'fs';
+import {promises as fs, createWriteStream, WriteStream} from 'fs';
+import {randomUUID} from 'crypto';
 import path from 'path';
 import {inject, injectable} from 'inversify';
 import {TYPES} from '../types.js';
@@ -10,7 +11,7 @@ import {FileCache} from '@prisma/client';
 
 @injectable()
 export default class FileCacheProvider {
-  private static readonly evictionQueue = new PQueue({concurrency: 1});
+  private static readonly mutationQueue = new PQueue({concurrency: 1});
   private readonly config: Config;
 
   constructor(@inject(TYPES.Config) config: Config) {
@@ -66,28 +67,16 @@ export default class FileCacheProvider {
    * @param hash lookup key
    */
   createWriteStream(hash: string) {
-    const tmpPath = path.join(this.config.CACHE_DIR, 'tmp', hash);
+    const tmpPath = path.join(this.config.CACHE_DIR, 'tmp', `${hash}.${randomUUID()}`);
     const finalPath = path.join(this.config.CACHE_DIR, hash);
 
     const stream = createWriteStream(tmpPath);
 
-    stream.on('close', async () => {
-      // Only move if size is non-zero (may have errored out)
-      const stats = await fs.stat(tmpPath);
-
-      if (stats.size !== 0) {
-        await fs.rename(tmpPath, finalPath);
-
-        await prisma.fileCache.create({
-          data: {
-            hash,
-            accessedAt: new Date(),
-            bytes: stats.size,
-          },
+    stream.once('close', () => {
+      void this.finalizeWrite(hash, tmpPath, finalPath)
+        .catch(error => {
+          this.reportFinalizationError(stream, error);
         });
-      }
-
-      await this.evictOldestIfNecessary();
     });
 
     return stream;
@@ -99,14 +88,87 @@ export default class FileCacheProvider {
    * will be evicted if the cache limit has changed.
    */
   async cleanup() {
-    await this.removeOrphans();
-    await this.evictOldestIfNecessary();
+    await FileCacheProvider.mutationQueue.add(async () => {
+      await this.removeOrphans();
+      await this.evictOldest();
+    });
   }
 
-  private async evictOldestIfNecessary() {
-    void FileCacheProvider.evictionQueue.add(this.evictOldest.bind(this));
+  private async finalizeWrite(hash: string, tmpPath: string, finalPath: string) {
+    try {
+      const temporaryStats = await fs.stat(tmpPath);
 
-    return FileCacheProvider.evictionQueue.onEmpty();
+      await FileCacheProvider.mutationQueue.add(async () => {
+        if (temporaryStats.size !== 0) {
+          try {
+            // Tmp and final are on one filesystem. A hard link publishes one
+            // complete writer atomically without replacing an existing winner.
+            await fs.link(tmpPath, finalPath);
+          } catch (error: unknown) {
+            if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+              throw error;
+            }
+          }
+
+          const finalStats = await fs.stat(finalPath);
+          const accessedAt = new Date();
+          await prisma.fileCache.upsert({
+            where: {
+              hash,
+            },
+            create: {
+              hash,
+              accessedAt,
+              bytes: finalStats.size,
+            },
+            update: {
+              accessedAt,
+              bytes: finalStats.size,
+            },
+          });
+        }
+
+        // This task already owns the mutation queue; enqueueing again here
+        // would deadlock behind itself.
+        await this.evictOldest();
+      });
+    } catch (error: unknown) {
+      try {
+        await this.removeTemporaryFile(tmpPath);
+      } catch (cleanupError: unknown) {
+        const message = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+        debug(`Failed to clean up cache temporary file: ${message}`);
+      }
+
+      throw error;
+    }
+
+    await this.removeTemporaryFile(tmpPath);
+  }
+
+  private async removeTemporaryFile(tmpPath: string) {
+    try {
+      await fs.unlink(tmpPath);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  private reportFinalizationError(stream: WriteStream, error: unknown) {
+    const finalizationError = error instanceof Error ? error : new Error(String(error));
+    console.error('Failed to finalize cache write:', finalizationError);
+    debug(`Failed to finalize cache write: ${finalizationError.message}`);
+
+    if (stream.listenerCount('error') > 0) {
+      try {
+        stream.emit('error', finalizationError);
+      } catch (reportingError: unknown) {
+        const message = reportingError instanceof Error ? reportingError.message : String(reportingError);
+        debug(`Cache write error listener failed: ${message}`);
+      }
+    }
   }
 
   private async evictOldest() {
@@ -124,16 +186,18 @@ export default class FileCacheProvider {
 
       });
 
-      if (oldest) {
-        await prisma.fileCache.delete({
-          where: {
-            hash: oldest.hash,
-          },
-        });
-        await fs.unlink(path.join(this.config.CACHE_DIR, oldest.hash));
-        debug(`${oldest.hash} has been evicted`);
-        numOfEvictedFiles++;
+      if (!oldest) {
+        throw new Error(`Cache usage is ${totalSizeBytes} bytes, above the configured limit of ${this.config.CACHE_LIMIT_IN_BYTES} bytes, but no indexed file is available to evict`);
       }
+
+      await prisma.fileCache.delete({
+        where: {
+          hash: oldest.hash,
+        },
+      });
+      await fs.unlink(path.join(this.config.CACHE_DIR, oldest.hash));
+      debug(`${oldest.hash} has been evicted`);
+      numOfEvictedFiles++;
 
       totalSizeBytes = await this.getDiskUsageInBytes();
     }

--- a/src/services/file-cache.ts
+++ b/src/services/file-cache.ts
@@ -299,17 +299,17 @@ export default class FileCacheProvider {
    */
   private getFindAllIterable() {
     const limit = 50;
-    let previousCreatedAt: Date | null = null;
+    let previousHash: string | null = null;
 
     let models: FileCache[] = [];
 
     const fetchNextBatch = async () => {
       let where;
 
-      if (previousCreatedAt) {
+      if (previousHash !== null) {
         where = {
-          createdAt: {
-            gt: previousCreatedAt,
+          hash: {
+            gt: previousHash,
           },
         };
       }
@@ -317,13 +317,13 @@ export default class FileCacheProvider {
       models = await prisma.fileCache.findMany({
         where,
         orderBy: {
-          createdAt: 'asc',
+          hash: 'asc',
         },
         take: limit,
       });
 
       if (models.length > 0) {
-        previousCreatedAt = models[models.length - 1].createdAt;
+        previousHash = models[models.length - 1].hash;
       }
     };
 

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -20,76 +20,76 @@ export default class {
   async getSongs(query: string, playlistLimit: number, shouldSplitChapters: boolean): Promise<[SongMetadata[], string]> {
     const newSongs: SongMetadata[] = [];
     let extraMsg = '';
+    let url: URL;
 
     // Test if it's a complete URL
     try {
-      const url = new URL(query);
-
-      const YOUTUBE_HOSTS = [
-        'www.youtube.com',
-        'youtu.be',
-        'youtube.com',
-        'music.youtube.com',
-        'www.music.youtube.com',
-      ];
-
-      if (YOUTUBE_HOSTS.includes(url.host)) {
-        // YouTube source
-        if (url.searchParams.get('list')) {
-          // YouTube playlist
-          newSongs.push(...await this.youtubePlaylist(url.searchParams.get('list')!, shouldSplitChapters));
-        } else {
-          const songs = await this.youtubeVideo(url.href, shouldSplitChapters);
-
-          if (songs) {
-            newSongs.push(...songs);
-          } else {
-            throw new Error('that doesn\'t exist');
-          }
-        }
-      } else if (url.protocol === 'spotify:' || url.host === 'open.spotify.com') {
-        if (this.spotifyAPI === undefined) {
-          throw new Error('Spotify is not enabled!');
-        }
-
-        const [convertedSongs, nSongsNotFound, totalSongs] = await this.spotifySource(query, playlistLimit, shouldSplitChapters);
-
-        if (totalSongs > playlistLimit) {
-          extraMsg = `a random sample of ${playlistLimit} songs was taken`;
-        }
-
-        if (totalSongs > playlistLimit && nSongsNotFound !== 0) {
-          extraMsg += ' and ';
-        }
-
-        if (nSongsNotFound !== 0) {
-          if (nSongsNotFound === 1) {
-            extraMsg += '1 song was not found';
-          } else {
-            extraMsg += `${nSongsNotFound.toString()} songs were not found`;
-          }
-        }
-
-        newSongs.push(...convertedSongs);
-      } else {
-        const song = await this.httpLiveStream(query);
-
-        if (song) {
-          newSongs.push(song);
-        } else {
-          throw new Error('that doesn\'t exist');
-        }
-      }
-    } catch (err: any) {
-      if (err instanceof Error && err.message === 'Spotify is not enabled!') {
-        throw err;
-      }
-
+      url = new URL(query);
+    } catch (_: unknown) {
       // Not a URL, must search YouTube
       const songs = await this.youtubeVideoSearch(query, shouldSplitChapters);
 
       if (songs) {
         newSongs.push(...songs);
+      } else {
+        throw new Error('that doesn\'t exist');
+      }
+
+      return [newSongs, extraMsg];
+    }
+
+    const YOUTUBE_HOSTS = [
+      'www.youtube.com',
+      'youtu.be',
+      'youtube.com',
+      'music.youtube.com',
+      'www.music.youtube.com',
+    ];
+
+    if (YOUTUBE_HOSTS.includes(url.host)) {
+      // YouTube source
+      if (url.searchParams.get('list')) {
+        // YouTube playlist
+        const songs = await this.youtubePlaylist(url.searchParams.get('list')!, shouldSplitChapters);
+        newSongs.push(...songs.slice(0, playlistLimit));
+      } else {
+        const songs = await this.youtubeVideo(url.href, shouldSplitChapters);
+
+        if (songs) {
+          newSongs.push(...songs);
+        } else {
+          throw new Error('that doesn\'t exist');
+        }
+      }
+    } else if (url.protocol === 'spotify:' || url.host === 'open.spotify.com') {
+      if (this.spotifyAPI === undefined) {
+        throw new Error('Spotify is not enabled!');
+      }
+
+      const [convertedSongs, nSongsNotFound, totalSongs] = await this.spotifySource(query, playlistLimit, shouldSplitChapters);
+
+      if (totalSongs > playlistLimit) {
+        extraMsg = `a random sample of ${playlistLimit} songs was taken`;
+      }
+
+      if (totalSongs > playlistLimit && nSongsNotFound !== 0) {
+        extraMsg += ' and ';
+      }
+
+      if (nSongsNotFound !== 0) {
+        if (nSongsNotFound === 1) {
+          extraMsg += '1 song was not found';
+        } else {
+          extraMsg += `${nSongsNotFound.toString()} songs were not found`;
+        }
+      }
+
+      newSongs.push(...convertedSongs);
+    } else {
+      const song = await this.httpLiveStream(query);
+
+      if (song) {
+        newSongs.push(song);
       } else {
         throw new Error('that doesn\'t exist');
       }
@@ -148,7 +148,8 @@ export default class {
     return new Promise((resolve, reject) => {
       ffmpeg(url).ffprobe((err, _) => {
         if (err) {
-          reject();
+          reject(err);
+          return;
         }
 
         resolve({
@@ -175,6 +176,10 @@ export default class {
     // Count songs that couldn't be found
     const songs: SongMetadata[] = searchResults.reduce((accum: SongMetadata[], result) => {
       if (result.status === 'fulfilled') {
+        if (result.value.length === 0) {
+          nSongsNotFound++;
+        }
+
         for (const v of result.value) {
           accum.push({
             ...v,

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -20,13 +20,19 @@ export default class {
   async getSongs(query: string, playlistLimit: number, shouldSplitChapters: boolean): Promise<[SongMetadata[], string]> {
     const newSongs: SongMetadata[] = [];
     let extraMsg = '';
-    let url: URL;
+    let url: URL | undefined;
 
     // Test if it's a complete URL
     try {
       url = new URL(query);
     } catch (_: unknown) {
-      // Not a URL, must search YouTube
+      url = undefined;
+    }
+
+    const supportedProtocols = ['http:', 'https:', 'spotify:'];
+
+    if (!url || !supportedProtocols.includes(url.protocol)) {
+      // Not a supported provider URL, so search YouTube as free text.
       const songs = await this.youtubeVideoSearch(query, shouldSplitChapters);
 
       if (songs) {

--- a/src/services/playback-attempt.ts
+++ b/src/services/playback-attempt.ts
@@ -1,0 +1,61 @@
+export interface PlaybackAttemptToken {
+  readonly id: number;
+}
+
+export interface PlaybackAttemptContext<Song, Connection> {
+  readonly attempt: PlaybackAttemptToken;
+  readonly song: Song;
+  readonly queueEntryVersion: number;
+  readonly connection: Connection;
+}
+
+export interface PlaybackOwnerSnapshot<Song, Connection> {
+  readonly currentSong: Song | null;
+  readonly queueEntryVersion: number | null;
+  readonly currentConnection: Connection | null;
+}
+
+export class PlaybackAttemptTracker<Song, Connection> {
+  private currentAttempt: PlaybackAttemptToken = {id: 0};
+
+  constructor(private readonly getOwnerSnapshot: () => PlaybackOwnerSnapshot<Song, Connection>) {}
+
+  begin(): PlaybackAttemptToken {
+    this.currentAttempt = {id: this.currentAttempt.id + 1};
+    return this.currentAttempt;
+  }
+
+  invalidate(): void {
+    this.currentAttempt = {id: this.currentAttempt.id + 1};
+  }
+
+  latest(): PlaybackAttemptToken {
+    return this.currentAttempt;
+  }
+
+  isLatest(attempt: PlaybackAttemptToken): boolean {
+    return attempt.id === this.currentAttempt.id;
+  }
+
+  isCurrent(attempt: PlaybackAttemptToken, connection: Connection): boolean {
+    return this.isLatest(attempt)
+      && this.getOwnerSnapshot().currentConnection === connection;
+  }
+
+  capture(
+    attempt: PlaybackAttemptToken,
+    song: Song,
+    queueEntryVersion: number,
+    connection: Connection,
+  ): PlaybackAttemptContext<Song, Connection> {
+    return {attempt, song, queueEntryVersion, connection};
+  }
+
+  owns(context: PlaybackAttemptContext<Song, Connection>): boolean {
+    const owner = this.getOwnerSnapshot();
+    return this.isLatest(context.attempt)
+      && owner.currentSong === context.song
+      && owner.queueEntryVersion === context.queueEntryVersion
+      && owner.currentConnection === context.connection;
+  }
+}

--- a/src/services/player-types.ts
+++ b/src/services/player-types.ts
@@ -1,0 +1,42 @@
+import type {Snowflake} from 'discord.js';
+
+export enum MediaSource {
+  Youtube,
+  HLS,
+}
+
+export interface QueuedPlaylist {
+  title: string;
+  source: string;
+}
+
+export interface SongMetadata {
+  title: string;
+  artist: string;
+  url: string; // For YT, it's the video ID (not the full URI)
+  length: number;
+  offset: number;
+  playlist: QueuedPlaylist | null;
+  isLive: boolean;
+  thumbnailUrl: string | null;
+  source: MediaSource;
+}
+
+export interface QueuedSong extends SongMetadata {
+  addedInChannelId: Snowflake;
+  requestedBy: string;
+}
+
+export type AgeRestrictedFallbackResolver = (song: QueuedSong) => Promise<SongMetadata | null>;
+
+export enum STATUS {
+  PLAYING,
+  PAUSED,
+  IDLE,
+}
+
+export interface PlayerEvents {
+  statusChange: (oldStatus: STATUS, newStatus: STATUS) => void;
+}
+
+export const DEFAULT_VOLUME = 100;

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -431,14 +431,14 @@ export default class {
     return this.queue.slice(this.queuePosition + 1);
   }
 
-  add(song: QueuedSong, {immediate = false} = {}): void {
-    if (song.playlist || !immediate) {
+  add(song: QueuedSong, {immediate = false, immediateOffset = 0} = {}): void {
+    if (immediate) {
+      // Add as the next song to be played
+      const insertAt = this.queuePosition + immediateOffset + 1;
+      this.queue = [...this.queue.slice(0, insertAt), song, ...this.queue.slice(insertAt)];
+    } else {
       // Add to end of queue
       this.queue.push(song);
-    } else {
-      // Add as the next song to be played
-      const insertAt = this.queuePosition + 1;
-      this.queue = [...this.queue.slice(0, insertAt), song, ...this.queue.slice(insertAt)];
     }
   }
 

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -758,10 +758,12 @@ export default class {
     if (this.voiceConnection.rejoinAttempts < 5) {
       await sleep((this.voiceConnection.rejoinAttempts + 1) * 5_000);
 
-      if (this.voiceConnection && this.voiceConnection.state.status === VoiceConnectionStatus.Disconnected) {
-        if (this.voiceConnection.rejoin()) {
-          return;
-        }
+      if (!this.voiceConnection || this.voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
+        return;
+      }
+
+      if (this.voiceConnection.rejoin()) {
+        return;
       }
     }
 

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -154,9 +154,7 @@ export default class {
       await this.waitForVoiceConnectionReady(voiceConnection);
     } catch {
       const {status} = voiceConnection.state;
-      if (status !== VoiceConnectionStatus.Destroyed) {
-        voiceConnection.destroy();
-      }
+      this.destroyVoiceConnection(voiceConnection);
 
       if (this.voiceConnection === voiceConnection) {
         this.voiceConnection = null;
@@ -176,7 +174,7 @@ export default class {
       }
 
       this.loopCurrentSong = false;
-      this.voiceConnection.destroy();
+      this.destroyVoiceConnection(this.voiceConnection);
       this.stopAudioPlayer(true);
 
       this.voiceConnection = null;
@@ -748,7 +746,16 @@ export default class {
   }
 
   private async onVoiceConnectionDisconnect(voiceConnection: VoiceConnection): Promise<void> {
-    if (this.voiceConnection !== voiceConnection || voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
+    if (this.voiceConnection !== voiceConnection) {
+      this.destroyVoiceConnection(voiceConnection);
+      return;
+    }
+
+    if (voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
+      if (voiceConnection.state.status === VoiceConnectionStatus.Destroyed) {
+        this.disconnect();
+      }
+
       return;
     }
 
@@ -759,10 +766,18 @@ export default class {
           entersState(voiceConnection, VoiceConnectionStatus.Connecting, 5_000),
           entersState(voiceConnection, VoiceConnectionStatus.Signalling, 5_000),
         ]);
+        if (this.voiceConnection !== voiceConnection) {
+          this.destroyVoiceConnection(voiceConnection);
+        } else if (this.getVoiceConnectionStatus(voiceConnection) === VoiceConnectionStatus.Destroyed) {
+          this.disconnect();
+        }
+
         return;
       } catch {
         if (this.voiceConnection === voiceConnection) {
           this.disconnect();
+        } else {
+          this.destroyVoiceConnection(voiceConnection);
         }
 
         return;
@@ -772,7 +787,17 @@ export default class {
     if (voiceConnection.rejoinAttempts < 5) {
       await sleep((voiceConnection.rejoinAttempts + 1) * 5_000);
 
-      if (this.voiceConnection !== voiceConnection || voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
+      if (this.voiceConnection !== voiceConnection) {
+        this.destroyVoiceConnection(voiceConnection);
+        return;
+      }
+
+      const connectionStatus = this.getVoiceConnectionStatus(voiceConnection);
+      if (connectionStatus !== VoiceConnectionStatus.Disconnected) {
+        if (connectionStatus === VoiceConnectionStatus.Destroyed) {
+          this.disconnect();
+        }
+
         return;
       }
 
@@ -783,7 +808,19 @@ export default class {
 
     if (this.voiceConnection === voiceConnection) {
       this.disconnect();
+    } else {
+      this.destroyVoiceConnection(voiceConnection);
     }
+  }
+
+  private destroyVoiceConnection(voiceConnection: VoiceConnection): void {
+    if (voiceConnection.state.status !== VoiceConnectionStatus.Destroyed) {
+      voiceConnection.destroy();
+    }
+  }
+
+  private getVoiceConnectionStatus(voiceConnection: VoiceConnection): VoiceConnectionStatus {
+    return voiceConnection.state.status;
   }
 
   private async ensureVoiceConnectionReady(): Promise<VoiceConnection> {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -440,6 +440,10 @@ export default class {
     return null;
   }
 
+  getCurrentQueueEntryId(): number | null {
+    return this.getCurrent() === null ? null : this.currentQueueEntryVersion;
+  }
+
   /**
    * Returns queue, not including the current song.
    * @returns {QueuedSong[]}

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -82,6 +82,7 @@ export default class {
   private currentQueueEntryVersion = 0;
   private nowPlayingQueueEntryVersion: number | null = null;
   private playbackAttemptVersion = 0;
+  private readonly programmaticallyStoppedAudioPlayers = new WeakSet<AudioPlayer>();
   private playPositionInterval: NodeJS.Timeout | undefined;
 
   private positionInSeconds = 0;
@@ -165,7 +166,7 @@ export default class {
 
       this.loopCurrentSong = false;
       this.voiceConnection.destroy();
-      this.audioPlayer?.stop(true);
+      this.stopAudioPlayer(true);
 
       this.voiceConnection = null;
       this.audioPlayer = null;
@@ -634,9 +635,9 @@ export default class {
 
   private async getStream(song: QueuedSong, options: {seek?: number; to?: number} = {}): Promise<Readable> {
     if (this.status === STATUS.PLAYING) {
-      this.audioPlayer?.stop();
+      this.stopAudioPlayer();
     } else if (this.status === STATUS.PAUSED) {
-      this.audioPlayer?.stop(true);
+      this.stopAudioPlayer(true);
     }
 
     if (song.source === MediaSource.HLS) {
@@ -718,8 +719,16 @@ export default class {
       return;
     }
 
-    if (this.audioPlayer.listeners(AudioPlayerStatus.Idle).length === 0) {
-      this.audioPlayer.on(AudioPlayerStatus.Idle, (oldState, newState) => {
+    const {audioPlayer} = this;
+    const queueEntryVersion = this.currentQueueEntryVersion;
+    if (audioPlayer.listeners(AudioPlayerStatus.Idle).length === 0) {
+      audioPlayer.on(AudioPlayerStatus.Idle, (oldState, newState) => {
+        if (this.programmaticallyStoppedAudioPlayers.has(audioPlayer)
+          || this.audioPlayer !== audioPlayer
+          || this.currentQueueEntryVersion !== queueEntryVersion) {
+          return;
+        }
+
         void this.onAudioPlayerIdle(oldState, newState).catch(error => {
           console.error(`Audio player idle handler failed for guild ${this.guildId}:`, error);
         });
@@ -886,7 +895,7 @@ export default class {
     this.invalidatePlaybackAttempts();
     this.stopTrackingPosition();
     this.status = STATUS.IDLE;
-    this.audioPlayer?.stop(true);
+    this.stopAudioPlayer(true);
 
     const settings = await getGuildSettings(this.guildId);
 
@@ -972,6 +981,15 @@ export default class {
   private setAudioPlayerVolume(level?: number) {
     // Audio resource expects a float between 0 and 1 to represent level percentage
     this.audioResource?.volume?.setVolume((level ?? this.getVolume()) / 100);
+  }
+
+  private stopAudioPlayer(force = false): void {
+    if (!this.audioPlayer) {
+      return;
+    }
+
+    this.programmaticallyStoppedAudioPlayers.add(this.audioPlayer);
+    this.audioPlayer.stop(force);
   }
 
   private beginPlaybackAttempt(): number {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -137,20 +137,31 @@ export default class {
 
       debug(`Voice connection state changed: ${oldState.status} -> ${newState.status}`);
 
-      if (newState.status === VoiceConnectionStatus.Ready && !this.hasRegisteredVoiceActivityListener) {
+      if (this.voiceConnection === voiceConnection
+        && newState.status === VoiceConnectionStatus.Ready
+        && !this.hasRegisteredVoiceActivityListener) {
         this.registerVoiceActivityListener(guildSettings);
         this.hasRegisteredVoiceActivityListener = true;
       }
     });
 
-    voiceConnection.on(VoiceConnectionStatus.Disconnected, this.onVoiceConnectionDisconnect.bind(this));
+    voiceConnection.on(
+      VoiceConnectionStatus.Disconnected,
+      this.onVoiceConnectionDisconnect.bind(this, voiceConnection),
+    );
 
     try {
       await this.waitForVoiceConnectionReady(voiceConnection);
     } catch {
       const {status} = voiceConnection.state;
-      voiceConnection.destroy();
-      this.voiceConnection = null;
+      if (status !== VoiceConnectionStatus.Destroyed) {
+        voiceConnection.destroy();
+      }
+
+      if (this.voiceConnection === voiceConnection) {
+        this.voiceConnection = null;
+      }
+
       throw new Error(`Failed to connect to the voice channel (last state: ${status}, rejoin attempts: ${voiceConnection.rejoinAttempts}, recent states: ${stateTransitions.join(' -> ')}).`);
     }
   }
@@ -736,38 +747,43 @@ export default class {
     }
   }
 
-  private async onVoiceConnectionDisconnect(): Promise<void> {
-    if (!this.voiceConnection || this.voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
+  private async onVoiceConnectionDisconnect(voiceConnection: VoiceConnection): Promise<void> {
+    if (this.voiceConnection !== voiceConnection || voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
       return;
     }
 
-    const disconnectedState = this.voiceConnection.state;
+    const disconnectedState = voiceConnection.state;
     if (disconnectedState.reason === VoiceConnectionDisconnectReason.WebSocketClose && disconnectedState.closeCode === 4014) {
       try {
         await Promise.race([
-          entersState(this.voiceConnection, VoiceConnectionStatus.Connecting, 5_000),
-          entersState(this.voiceConnection, VoiceConnectionStatus.Signalling, 5_000),
+          entersState(voiceConnection, VoiceConnectionStatus.Connecting, 5_000),
+          entersState(voiceConnection, VoiceConnectionStatus.Signalling, 5_000),
         ]);
         return;
       } catch {
-        this.disconnect();
+        if (this.voiceConnection === voiceConnection) {
+          this.disconnect();
+        }
+
         return;
       }
     }
 
-    if (this.voiceConnection.rejoinAttempts < 5) {
-      await sleep((this.voiceConnection.rejoinAttempts + 1) * 5_000);
+    if (voiceConnection.rejoinAttempts < 5) {
+      await sleep((voiceConnection.rejoinAttempts + 1) * 5_000);
 
-      if (!this.voiceConnection || this.voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
+      if (this.voiceConnection !== voiceConnection || voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
         return;
       }
 
-      if (this.voiceConnection.rejoin()) {
+      if (voiceConnection.rejoin()) {
         return;
       }
     }
 
-    this.disconnect();
+    if (this.voiceConnection === voiceConnection) {
+      this.disconnect();
+    }
   }
 
   private async ensureVoiceConnectionReady(): Promise<VoiceConnection> {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -81,6 +81,7 @@ export default class {
   private nowPlaying: QueuedSong | null = null;
   private currentQueueEntryVersion = 0;
   private nowPlayingQueueEntryVersion: number | null = null;
+  private playbackAttemptVersion = 0;
   private playPositionInterval: NodeJS.Timeout | undefined;
 
   private positionInSeconds = 0;
@@ -154,6 +155,7 @@ export default class {
   }
 
   disconnect(): void {
+    this.invalidatePlaybackAttempts();
     this.voiceActivitySessionGeneration++;
 
     if (this.voiceConnection) {
@@ -177,40 +179,8 @@ export default class {
   }
 
   async seek(positionSeconds: number): Promise<void> {
-    this.status = STATUS.PAUSED;
-
-    const voiceConnection = await this.ensureVoiceConnectionReady();
-
-    const currentSong = this.getCurrent();
-
-    if (!currentSong) {
-      throw new Error('No song currently playing');
-    }
-
-    if (positionSeconds > currentSong.length) {
-      throw new Error('Seek position is outside the range of the song.');
-    }
-
-    let realPositionSeconds = positionSeconds;
-    let to: number | undefined;
-    if (currentSong.offset !== undefined) {
-      realPositionSeconds += currentSong.offset;
-      to = currentSong.length + currentSong.offset;
-    }
-
-    const stream = await this.getStream(currentSong, {seek: realPositionSeconds, to});
-    this.audioPlayer = createAudioPlayer({
-      behaviors: {
-        // Needs to be somewhat high for livestreams
-        maxMissedFrames: 50,
-      },
-    });
-    voiceConnection.subscribe(this.audioPlayer);
-    this.playAudioPlayerResource(this.createAudioStream(stream));
-    this.attachListeners();
-    this.startTrackingPosition(positionSeconds);
-
-    this.status = STATUS.PLAYING;
+    const playbackAttemptVersion = this.beginPlaybackAttempt();
+    await this.seekWithAttempt(positionSeconds, playbackAttemptVersion);
   }
 
   async forwardSeek(positionSeconds: number): Promise<void> {
@@ -222,83 +192,8 @@ export default class {
   }
 
   async play(allowAgeRestrictedFallback = true): Promise<void> {
-    const voiceConnection = await this.ensureVoiceConnectionReady();
-
-    const currentSong = this.getCurrent();
-
-    if (!currentSong) {
-      throw new Error('Queue empty.');
-    }
-
-    // Cancel any pending idle disconnection
-    if (this.disconnectTimer) {
-      clearInterval(this.disconnectTimer);
-      this.disconnectTimer = null;
-    }
-
-    // Resume from paused state
-    if (this.status === STATUS.PAUSED
-      && currentSong === this.nowPlaying
-      && this.currentQueueEntryVersion === this.nowPlayingQueueEntryVersion) {
-      if (this.audioPlayer) {
-        this.audioPlayer.unpause();
-        this.status = STATUS.PLAYING;
-        this.startTrackingPosition();
-        return;
-      }
-
-      // Was disconnected, need to recreate stream
-      if (!currentSong.isLive) {
-        return this.seek(this.getPosition());
-      }
-    }
-
-    try {
-      let positionSeconds: number | undefined;
-      let to: number | undefined;
-      if (currentSong.offset !== undefined) {
-        positionSeconds = currentSong.offset;
-        to = currentSong.length + currentSong.offset;
-      }
-
-      const stream = await this.getStream(currentSong, {seek: positionSeconds, to});
-      this.audioPlayer = createAudioPlayer({
-        behaviors: {
-          // Needs to be somewhat high for livestreams
-          maxMissedFrames: 50,
-        },
-      });
-      voiceConnection.subscribe(this.audioPlayer);
-      this.playAudioPlayerResource(this.createAudioStream(stream));
-
-      this.attachListeners();
-
-      this.status = STATUS.PLAYING;
-      this.nowPlaying = currentSong;
-      this.nowPlayingQueueEntryVersion = this.currentQueueEntryVersion;
-      this.startTrackingPosition(0);
-    } catch (error: unknown) {
-      const isGone = typeof error === 'object'
-        && error !== null
-        && 'statusCode' in error
-        && error.statusCode === 410;
-
-      if (error instanceof YtDlpMediaUnavailableError
-        && error.reason === 'age-restricted'
-        && allowAgeRestrictedFallback
-        && await this.tryAgeRestrictedAudioFallback(currentSong)) {
-        return;
-      }
-
-      if (error instanceof YtDlpMediaUnavailableError || isGone) {
-        const detail = error instanceof Error ? error.message : 'media returned HTTP 410';
-        console.warn(`Skipping unplayable YouTube track for guild ${this.guildId}: ${detail}`);
-        await this.advancePastUnplayableTrack();
-        return;
-      }
-
-      throw error;
-    }
+    const playbackAttemptVersion = this.beginPlaybackAttempt();
+    await this.playWithAttempt(playbackAttemptVersion, allowAgeRestrictedFallback);
   }
 
   pause(): void {
@@ -306,6 +201,7 @@ export default class {
       throw new Error('Not currently playing.');
     }
 
+    this.invalidatePlaybackAttempts();
     this.status = STATUS.PAUSED;
 
     if (this.audioPlayer) {
@@ -319,16 +215,28 @@ export default class {
     const originalQueuePosition = this.queuePosition;
     const originalQueueEntryVersion = this.currentQueueEntryVersion;
     this.manualForward(skip);
+    const destinationSong = this.getCurrent();
+    const destinationQueueEntryVersion = this.currentQueueEntryVersion;
+    let destinationPlaybackAttemptVersion: number | null = null;
 
     try {
-      if (!this.getCurrent()) {
+      if (!destinationSong) {
         await this.finishQueue();
       } else if (this.status !== STATUS.PAUSED) {
-        await this.play();
+        const playPromise = this.play();
+        destinationPlaybackAttemptVersion = this.playbackAttemptVersion;
+        await playPromise;
       }
     } catch (error: unknown) {
-      this.queuePosition = originalQueuePosition;
-      this.currentQueueEntryVersion = originalQueueEntryVersion;
+      const failedTransitionStillOwnsDestination = this.getCurrent() === destinationSong
+        && this.currentQueueEntryVersion === destinationQueueEntryVersion
+        && (destinationPlaybackAttemptVersion === null
+          || this.playbackAttemptVersion === destinationPlaybackAttemptVersion);
+      if (failedTransitionStillOwnsDestination) {
+        this.queuePosition = originalQueuePosition;
+        this.currentQueueEntryVersion = originalQueueEntryVersion;
+      }
+
       throw error;
     }
   }
@@ -540,6 +448,186 @@ export default class {
     return this.voiceActivityVolumeTarget ?? this.volume ?? this.defaultVolume;
   }
 
+  private async seekWithAttempt(positionSeconds: number, playbackAttemptVersion: number): Promise<void> {
+    this.status = STATUS.PAUSED;
+
+    const currentSong = this.getCurrent();
+    const currentQueueEntryVersion = this.getCurrentQueueEntryId();
+    const voiceConnection = await this.ensureVoiceConnectionReady();
+
+    if (!this.isPlaybackAttemptCurrent(playbackAttemptVersion, voiceConnection)) {
+      return;
+    }
+
+    if (!currentSong) {
+      throw new Error('No song currently playing');
+    }
+
+    if (currentQueueEntryVersion === null
+      || !this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+      return;
+    }
+
+    if (positionSeconds > currentSong.length) {
+      throw new Error('Seek position is outside the range of the song.');
+    }
+
+    let realPositionSeconds = positionSeconds;
+    let to: number | undefined;
+    if (currentSong.offset !== undefined) {
+      realPositionSeconds += currentSong.offset;
+      to = currentSong.length + currentSong.offset;
+    }
+
+    const stream = await this.getStream(currentSong, {seek: realPositionSeconds, to});
+    if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+      this.destroyStaleStream(stream);
+      return;
+    }
+
+    this.audioPlayer = createAudioPlayer({
+      behaviors: {
+        // Needs to be somewhat high for livestreams
+        maxMissedFrames: 50,
+      },
+    });
+    voiceConnection.subscribe(this.audioPlayer);
+    this.playAudioPlayerResource(this.createAudioStream(stream));
+    this.attachListeners();
+    this.startTrackingPosition(positionSeconds);
+
+    this.status = STATUS.PLAYING;
+    this.nowPlaying = currentSong;
+    this.nowPlayingQueueEntryVersion = currentQueueEntryVersion;
+  }
+
+  private async playWithAttempt(playbackAttemptVersion: number, allowAgeRestrictedFallback: boolean): Promise<void> {
+    const currentSong = this.getCurrent();
+    const currentQueueEntryVersion = this.getCurrentQueueEntryId();
+    const voiceConnection = await this.ensureVoiceConnectionReady();
+
+    if (!this.isPlaybackAttemptCurrent(playbackAttemptVersion, voiceConnection)) {
+      return;
+    }
+
+    if (!currentSong) {
+      throw new Error('Queue empty.');
+    }
+
+    if (currentQueueEntryVersion === null
+      || !this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+      return;
+    }
+
+    // Cancel any pending idle disconnection
+    if (this.disconnectTimer) {
+      clearInterval(this.disconnectTimer);
+      this.disconnectTimer = null;
+    }
+
+    // Resume from paused state
+    if (this.status === STATUS.PAUSED
+      && currentSong === this.nowPlaying
+      && this.currentQueueEntryVersion === this.nowPlayingQueueEntryVersion) {
+      if (this.audioPlayer) {
+        this.audioPlayer.unpause();
+        this.status = STATUS.PLAYING;
+        this.startTrackingPosition();
+        return;
+      }
+
+      // Was disconnected, need to recreate stream
+      if (!currentSong.isLive) {
+        return this.seekWithAttempt(this.getPosition(), playbackAttemptVersion);
+      }
+    }
+
+    try {
+      let positionSeconds: number | undefined;
+      let to: number | undefined;
+      if (currentSong.offset !== undefined) {
+        positionSeconds = currentSong.offset;
+        to = currentSong.length + currentSong.offset;
+      }
+
+      const stream = await this.getStream(currentSong, {seek: positionSeconds, to});
+      if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+        this.destroyStaleStream(stream);
+        return;
+      }
+
+      this.audioPlayer = createAudioPlayer({
+        behaviors: {
+          // Needs to be somewhat high for livestreams
+          maxMissedFrames: 50,
+        },
+      });
+      voiceConnection.subscribe(this.audioPlayer);
+      this.playAudioPlayerResource(this.createAudioStream(stream));
+
+      this.attachListeners();
+
+      this.status = STATUS.PLAYING;
+      this.nowPlaying = currentSong;
+      this.nowPlayingQueueEntryVersion = currentQueueEntryVersion;
+      this.startTrackingPosition(0);
+    } catch (error: unknown) {
+      await this.handlePlaybackError(
+        error,
+        {currentSong, currentQueueEntryVersion, playbackAttemptVersion, voiceConnection},
+        allowAgeRestrictedFallback,
+      );
+    }
+  }
+
+  private async handlePlaybackError(
+    error: unknown,
+    playback: {
+      currentSong: QueuedSong;
+      currentQueueEntryVersion: number;
+      playbackAttemptVersion: number;
+      voiceConnection: VoiceConnection;
+    },
+    allowAgeRestrictedFallback: boolean,
+  ): Promise<void> {
+    const {currentSong, currentQueueEntryVersion, playbackAttemptVersion, voiceConnection} = playback;
+    if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+      throw error;
+    }
+
+    const isGone = typeof error === 'object'
+      && error !== null
+      && 'statusCode' in error
+      && error.statusCode === 410;
+
+    if (error instanceof YtDlpMediaUnavailableError
+      && error.reason === 'age-restricted'
+      && allowAgeRestrictedFallback) {
+      const fallbackHandled = await this.tryAgeRestrictedAudioFallback(
+        currentSong,
+        currentQueueEntryVersion,
+        playbackAttemptVersion,
+        voiceConnection,
+      );
+      if (fallbackHandled) {
+        return;
+      }
+
+      if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+        throw error;
+      }
+    }
+
+    if (error instanceof YtDlpMediaUnavailableError || isGone) {
+      const detail = error instanceof Error ? error.message : 'media returned HTTP 410';
+      console.warn(`Skipping unplayable YouTube track for guild ${this.guildId}: ${detail}`);
+      await this.advancePastUnplayableTrack();
+      return;
+    }
+
+    throw error;
+  }
+
   private getHashForCache(url: string): string {
     return hasha(url);
   }
@@ -696,20 +784,33 @@ export default class {
     await this.play();
   }
 
-  private async tryAgeRestrictedAudioFallback(song: QueuedSong): Promise<boolean> {
+  private async tryAgeRestrictedAudioFallback(
+    song: QueuedSong,
+    queueEntryVersion: number,
+    playbackAttemptVersion: number,
+    voiceConnection: VoiceConnection,
+  ): Promise<boolean> {
     if (!this.ageRestrictedFallbackResolver || song.source !== MediaSource.Youtube) {
       return false;
+    }
+
+    if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, song, queueEntryVersion, voiceConnection)) {
+      return true;
     }
 
     let fallback: SongMetadata | null;
     try {
       fallback = await this.ageRestrictedFallbackResolver(song);
     } catch {
+      if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, song, queueEntryVersion, voiceConnection)) {
+        return true;
+      }
+
       console.warn(`Audio fallback search failed for age-restricted track in guild ${this.guildId}.`);
       return false;
     }
 
-    if (this.getCurrent() !== song) {
+    if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, song, queueEntryVersion, voiceConnection)) {
       return true;
     }
 
@@ -728,10 +829,11 @@ export default class {
     console.warn(`Trying audio fallback for age-restricted YouTube track in guild ${this.guildId}: ${song.url} -> ${replacement.url}`);
 
     try {
-      await this.play(false);
+      await this.playWithAttempt(playbackAttemptVersion, false);
       return true;
     } catch (error: unknown) {
-      if (this.queue[queuePosition] === replacement) {
+      if (this.isPlaybackAttemptOwner(playbackAttemptVersion, replacement, queueEntryVersion, voiceConnection)
+        && this.queue[queuePosition] === replacement) {
         this.queue[queuePosition] = song;
       }
 
@@ -781,6 +883,7 @@ export default class {
   }
 
   private async finishQueue(): Promise<void> {
+    this.invalidatePlaybackAttempts();
     this.stopTrackingPosition();
     this.status = STATUS.IDLE;
     this.audioPlayer?.stop(true);
@@ -869,5 +972,39 @@ export default class {
   private setAudioPlayerVolume(level?: number) {
     // Audio resource expects a float between 0 and 1 to represent level percentage
     this.audioResource?.volume?.setVolume((level ?? this.getVolume()) / 100);
+  }
+
+  private beginPlaybackAttempt(): number {
+    this.playbackAttemptVersion++;
+    return this.playbackAttemptVersion;
+  }
+
+  private invalidatePlaybackAttempts(): void {
+    this.playbackAttemptVersion++;
+  }
+
+  private isPlaybackAttemptOwner(
+    playbackAttemptVersion: number,
+    song: QueuedSong,
+    queueEntryVersion: number,
+    voiceConnection: VoiceConnection,
+  ): boolean {
+    return this.isPlaybackAttemptCurrent(playbackAttemptVersion, voiceConnection)
+      && this.getCurrent() === song
+      && this.currentQueueEntryVersion === queueEntryVersion;
+  }
+
+  private isPlaybackAttemptCurrent(
+    playbackAttemptVersion: number,
+    voiceConnection: VoiceConnection,
+  ): boolean {
+    return this.playbackAttemptVersion === playbackAttemptVersion
+      && this.voiceConnection === voiceConnection;
+  }
+
+  private destroyStaleStream(stream: Readable): void {
+    if (!stream.destroyed) {
+      stream.destroy();
+    }
   }
 }

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -79,8 +79,9 @@ export default class {
   private volume?: number;
   private defaultVolume: number = DEFAULT_VOLUME;
   private nowPlaying: QueuedSong | null = null;
+  private currentQueueEntryVersion = 0;
+  private nowPlayingQueueEntryVersion: number | null = null;
   private playPositionInterval: NodeJS.Timeout | undefined;
-  private lastSongURL = '';
 
   private positionInSeconds = 0;
   private readonly fileCache: FileCacheProvider;
@@ -88,6 +89,9 @@ export default class {
   private disconnectTimer: NodeJS.Timeout | null = null;
 
   private readonly channelToSpeakingUsers: Map<string, Set<string>> = new Map();
+  private volumeBeforeVoiceActivity?: number;
+  private voiceActivityVolumeTarget?: number;
+  private voiceActivitySessionGeneration = 0;
   private hasRegisteredVoiceActivityListener = false;
 
   constructor(fileCache: FileCacheProvider, guildId: string, ageRestrictedFallbackResolver?: AgeRestrictedFallbackResolver) {
@@ -150,6 +154,8 @@ export default class {
   }
 
   disconnect(): void {
+    this.voiceActivitySessionGeneration++;
+
     if (this.voiceConnection) {
       if (this.status === STATUS.PLAYING) {
         this.pause();
@@ -164,6 +170,8 @@ export default class {
       this.audioResource = null;
       this.currentChannel = undefined;
       this.channelToSpeakingUsers.clear();
+      this.volumeBeforeVoiceActivity = undefined;
+      this.voiceActivityVolumeTarget = undefined;
       this.hasRegisteredVoiceActivityListener = false;
     }
   }
@@ -229,7 +237,9 @@ export default class {
     }
 
     // Resume from paused state
-    if (this.status === STATUS.PAUSED && currentSong.url === this.nowPlaying?.url) {
+    if (this.status === STATUS.PAUSED
+      && currentSong === this.nowPlaying
+      && this.currentQueueEntryVersion === this.nowPlayingQueueEntryVersion) {
       if (this.audioPlayer) {
         this.audioPlayer.unpause();
         this.status = STATUS.PLAYING;
@@ -265,14 +275,8 @@ export default class {
 
       this.status = STATUS.PLAYING;
       this.nowPlaying = currentSong;
-
-      if (currentSong.url === this.lastSongURL) {
-        this.startTrackingPosition();
-      } else {
-        // Reset position counter
-        this.startTrackingPosition(0);
-        this.lastSongURL = currentSong.url;
-      }
+      this.nowPlayingQueueEntryVersion = this.currentQueueEntryVersion;
+      this.startTrackingPosition(0);
     } catch (error: unknown) {
       const isGone = typeof error === 'object'
         && error !== null
@@ -312,33 +316,44 @@ export default class {
   }
 
   async forward(skip: number): Promise<void> {
+    const originalQueuePosition = this.queuePosition;
+    const originalQueueEntryVersion = this.currentQueueEntryVersion;
     this.manualForward(skip);
 
     try {
-      if (this.getCurrent() && this.status !== STATUS.PAUSED) {
-        await this.play();
-      } else {
+      if (!this.getCurrent()) {
         await this.finishQueue();
+      } else if (this.status !== STATUS.PAUSED) {
+        await this.play();
       }
     } catch (error: unknown) {
-      this.queuePosition--;
+      this.queuePosition = originalQueuePosition;
+      this.currentQueueEntryVersion = originalQueueEntryVersion;
       throw error;
     }
   }
 
   registerVoiceActivityListener(guildSettings: Setting) {
     const {turnDownVolumeWhenPeopleSpeak, turnDownVolumeWhenPeopleSpeakTarget} = guildSettings;
-    if (!turnDownVolumeWhenPeopleSpeak || !this.voiceConnection) {
+    const {voiceConnection, currentChannel} = this;
+    if (!turnDownVolumeWhenPeopleSpeak || !voiceConnection || !currentChannel) {
       return;
     }
 
-    this.voiceConnection.receiver.speaking.on('start', (userId: string) => {
-      if (!this.currentChannel) {
+    const voiceActivitySessionGeneration = ++this.voiceActivitySessionGeneration;
+    const isCurrentVoiceActivitySession = () => (
+      voiceActivitySessionGeneration === this.voiceActivitySessionGeneration
+      && voiceConnection === this.voiceConnection
+      && currentChannel === this.currentChannel
+    );
+
+    voiceConnection.receiver.speaking.on('start', (userId: string) => {
+      if (!isCurrentVoiceActivitySession()) {
         return;
       }
 
-      const member = this.currentChannel.members.get(userId);
-      const channelId = this.currentChannel?.id;
+      const member = currentChannel.members.get(userId);
+      const {id: channelId} = currentChannel;
 
       if (member) {
         if (!this.channelToSpeakingUsers.has(channelId)) {
@@ -351,20 +366,12 @@ export default class {
       this.suppressVoiceWhenPeopleAreSpeaking(turnDownVolumeWhenPeopleSpeakTarget);
     });
 
-    this.voiceConnection.receiver.speaking.on('end', (userId: string) => {
-      if (!this.currentChannel) {
+    voiceConnection.receiver.speaking.on('end', (userId: string) => {
+      if (!isCurrentVoiceActivitySession()) {
         return;
       }
 
-      const member = this.currentChannel.members.get(userId);
-      const channelId = this.currentChannel.id;
-      if (member) {
-        if (!this.channelToSpeakingUsers.has(channelId)) {
-          this.channelToSpeakingUsers.set(channelId, new Set());
-        }
-
-        this.channelToSpeakingUsers.get(channelId)?.delete(member.id);
-      }
+      this.channelToSpeakingUsers.get(currentChannel.id)?.delete(userId);
 
       this.suppressVoiceWhenPeopleAreSpeaking(turnDownVolumeWhenPeopleSpeakTarget);
     });
@@ -377,9 +384,17 @@ export default class {
 
     const speakingUsers = this.channelToSpeakingUsers.get(this.currentChannel.id);
     if (speakingUsers && speakingUsers.size > 0) {
-      this.setVolume(turnDownVolumeWhenPeopleSpeakTarget);
-    } else {
-      this.setVolume(this.defaultVolume);
+      if (this.volumeBeforeVoiceActivity === undefined) {
+        this.volumeBeforeVoiceActivity = this.getVolume();
+      }
+
+      this.voiceActivityVolumeTarget = turnDownVolumeWhenPeopleSpeakTarget;
+      this.setAudioPlayerVolume(turnDownVolumeWhenPeopleSpeakTarget);
+    } else if (this.volumeBeforeVoiceActivity !== undefined) {
+      const {volumeBeforeVoiceActivity} = this;
+      this.volumeBeforeVoiceActivity = undefined;
+      this.voiceActivityVolumeTarget = undefined;
+      this.setAudioPlayerVolume(volumeBeforeVoiceActivity);
     }
   }
 
@@ -390,6 +405,7 @@ export default class {
   manualForward(skip: number): void {
     if (this.canGoForward(skip)) {
       this.queuePosition += skip;
+      this.currentQueueEntryVersion++;
       this.positionInSeconds = 0;
       this.stopTrackingPosition();
     } else {
@@ -404,6 +420,7 @@ export default class {
   async back(): Promise<void> {
     if (this.canGoBack()) {
       this.queuePosition--;
+      this.currentQueueEntryVersion++;
       this.positionInSeconds = 0;
       this.stopTrackingPosition();
 
@@ -432,6 +449,8 @@ export default class {
   }
 
   add(song: QueuedSong, {immediate = false, immediateOffset = 0} = {}): void {
+    const currentSong = this.getCurrent();
+
     if (immediate) {
       // Add as the next song to be played
       const insertAt = this.queuePosition + immediateOffset + 1;
@@ -439,6 +458,10 @@ export default class {
     } else {
       // Add to end of queue
       this.queue.push(song);
+    }
+
+    if (this.getCurrent() !== currentSong) {
+      this.currentQueueEntryVersion++;
     }
   }
 
@@ -468,6 +491,7 @@ export default class {
 
   removeCurrent(): void {
     this.queue = [...this.queue.slice(0, this.queuePosition), ...this.queue.slice(this.queuePosition + 1)];
+    this.currentQueueEntryVersion++;
   }
 
   queueSize(): number {
@@ -482,6 +506,7 @@ export default class {
     this.disconnect();
     this.queuePosition = 0;
     this.queue = [];
+    this.currentQueueEntryVersion++;
   }
 
   move(from: number, to: number): QueuedSong {
@@ -497,12 +522,18 @@ export default class {
   setVolume(level: number): void {
     // Level should be a number between 0 and 100 = 0% => 100%
     this.volume = level;
-    this.setAudioPlayerVolume(level);
+
+    if (this.volumeBeforeVoiceActivity === undefined) {
+      this.setAudioPlayerVolume(level);
+    } else {
+      this.volumeBeforeVoiceActivity = level;
+      this.setAudioPlayerVolume(this.voiceActivityVolumeTarget);
+    }
   }
 
   getVolume(): number {
     // Only use default volume if player volume is not already set (in the event of a reconnect we shouldn't reset)
-    return this.volume ?? this.defaultVolume;
+    return this.voiceActivityVolumeTarget ?? this.volume ?? this.defaultVolume;
   }
 
   private getHashForCache(url: string): string {
@@ -582,6 +613,7 @@ export default class {
   private stopTrackingPosition(): void {
     if (this.playPositionInterval) {
       clearInterval(this.playPositionInterval);
+      this.playPositionInterval = undefined;
     }
   }
 
@@ -745,6 +777,7 @@ export default class {
   }
 
   private async finishQueue(): Promise<void> {
+    this.stopTrackingPosition();
     this.status = STATUS.IDLE;
     this.audioPlayer?.stop(true);
 

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -1,6 +1,5 @@
-import {VoiceChannel, Snowflake} from 'discord.js';
+import {VoiceChannel} from 'discord.js';
 import {Readable} from 'stream';
-import {setTimeout as sleep} from 'timers/promises';
 import hasha from 'hasha';
 import {WriteStream} from 'fs-capacitor';
 import ffmpeg from 'fluent-ffmpeg';
@@ -15,55 +14,31 @@ import {
   joinVoiceChannel,
   StreamType,
   VoiceConnection,
-  VoiceConnectionDisconnectReason,
   VoiceConnectionStatus,
 } from '@discordjs/voice';
 import FileCacheProvider from './file-cache.js';
+import {PlaybackAttemptTracker, type PlaybackAttemptContext, type PlaybackAttemptToken} from './playback-attempt.js';
+import {
+  DEFAULT_VOLUME,
+  MediaSource,
+  STATUS,
+  type AgeRestrictedFallbackResolver,
+  type PlayerEvents,
+  type QueuedPlaylist,
+  type QueuedSong,
+  type SongMetadata,
+} from './player-types.js';
+import {destroyVoiceConnection, recoverVoiceConnection} from './voice-connection-recovery.js';
 import debug from '../utils/debug.js';
 import {getGuildSettings} from '../utils/get-guild-settings.js';
 import {buildPlayingMessageEmbed} from '../utils/build-embed.js';
 import {getYouTubeMediaSource, YtDlpMediaUnavailableError} from '../utils/yt-dlp.js';
 import {Setting} from '@prisma/client';
 
-export enum MediaSource {
-  Youtube,
-  HLS,
-}
+export {DEFAULT_VOLUME, MediaSource, STATUS};
+export type {AgeRestrictedFallbackResolver, PlayerEvents, QueuedPlaylist, QueuedSong, SongMetadata};
 
-export interface QueuedPlaylist {
-  title: string;
-  source: string;
-}
-
-export interface SongMetadata {
-  title: string;
-  artist: string;
-  url: string; // For YT, it's the video ID (not the full URI)
-  length: number;
-  offset: number;
-  playlist: QueuedPlaylist | null;
-  isLive: boolean;
-  thumbnailUrl: string | null;
-  source: MediaSource;
-}
-export interface QueuedSong extends SongMetadata {
-  addedInChannelId: Snowflake;
-  requestedBy: string;
-}
-
-export type AgeRestrictedFallbackResolver = (song: QueuedSong) => Promise<SongMetadata | null>;
-
-export enum STATUS {
-  PLAYING,
-  PAUSED,
-  IDLE,
-}
-
-export interface PlayerEvents {
-  statusChange: (oldStatus: STATUS, newStatus: STATUS) => void;
-}
-
-export const DEFAULT_VOLUME = 100;
+type PlayerPlaybackAttemptContext = PlaybackAttemptContext<QueuedSong, VoiceConnection>;
 
 export default class {
   public voiceConnection: VoiceConnection | null = null;
@@ -81,7 +56,7 @@ export default class {
   private nowPlaying: QueuedSong | null = null;
   private currentQueueEntryVersion = 0;
   private nowPlayingQueueEntryVersion: number | null = null;
-  private playbackAttemptVersion = 0;
+  private readonly playbackAttempts: PlaybackAttemptTracker<QueuedSong, VoiceConnection>;
   private readonly programmaticallyStoppedAudioPlayers = new WeakSet<AudioPlayer>();
   private playPositionInterval: NodeJS.Timeout | undefined;
 
@@ -100,6 +75,11 @@ export default class {
     this.fileCache = fileCache;
     this.guildId = guildId;
     this.ageRestrictedFallbackResolver = ageRestrictedFallbackResolver;
+    this.playbackAttempts = new PlaybackAttemptTracker(() => ({
+      currentSong: this.getCurrent(),
+      queueEntryVersion: this.getCurrentQueueEntryId(),
+      currentConnection: this.voiceConnection,
+    }));
   }
 
   async connect(channel: VoiceChannel): Promise<void> {
@@ -154,7 +134,7 @@ export default class {
       await this.waitForVoiceConnectionReady(voiceConnection);
     } catch {
       const {status} = voiceConnection.state;
-      this.destroyVoiceConnection(voiceConnection);
+      destroyVoiceConnection(voiceConnection);
 
       if (this.voiceConnection === voiceConnection) {
         this.voiceConnection = null;
@@ -165,7 +145,7 @@ export default class {
   }
 
   disconnect(): void {
-    this.invalidatePlaybackAttempts();
+    this.playbackAttempts.invalidate();
     this.voiceActivitySessionGeneration++;
 
     if (this.voiceConnection) {
@@ -174,7 +154,7 @@ export default class {
       }
 
       this.loopCurrentSong = false;
-      this.destroyVoiceConnection(this.voiceConnection);
+      destroyVoiceConnection(this.voiceConnection);
       this.stopAudioPlayer(true);
 
       this.voiceConnection = null;
@@ -189,8 +169,8 @@ export default class {
   }
 
   async seek(positionSeconds: number): Promise<void> {
-    const playbackAttemptVersion = this.beginPlaybackAttempt();
-    await this.seekWithAttempt(positionSeconds, playbackAttemptVersion);
+    const attempt = this.playbackAttempts.begin();
+    await this.seekWithAttempt(positionSeconds, attempt);
   }
 
   async forwardSeek(positionSeconds: number): Promise<void> {
@@ -202,8 +182,8 @@ export default class {
   }
 
   async play(allowAgeRestrictedFallback = true): Promise<void> {
-    const playbackAttemptVersion = this.beginPlaybackAttempt();
-    await this.playWithAttempt(playbackAttemptVersion, allowAgeRestrictedFallback);
+    const attempt = this.playbackAttempts.begin();
+    await this.playWithAttempt(attempt, allowAgeRestrictedFallback);
   }
 
   pause(): void {
@@ -211,7 +191,7 @@ export default class {
       throw new Error('Not currently playing.');
     }
 
-    this.invalidatePlaybackAttempts();
+    this.playbackAttempts.invalidate();
     this.status = STATUS.PAUSED;
 
     if (this.audioPlayer) {
@@ -227,21 +207,29 @@ export default class {
     this.manualForward(skip);
     const destinationSong = this.getCurrent();
     const destinationQueueEntryVersion = this.currentQueueEntryVersion;
-    let destinationPlaybackAttemptVersion: number | null = null;
+    let destinationPlayback: PlayerPlaybackAttemptContext | null = null;
 
     try {
       if (!destinationSong) {
         await this.finishQueue();
       } else if (this.status !== STATUS.PAUSED) {
         const playPromise = this.play();
-        destinationPlaybackAttemptVersion = this.playbackAttemptVersion;
+        const destinationConnection = this.voiceConnection;
+        if (destinationConnection && destinationSong && destinationQueueEntryVersion !== null) {
+          destinationPlayback = this.playbackAttempts.capture(
+            this.playbackAttempts.latest(),
+            destinationSong,
+            destinationQueueEntryVersion,
+            destinationConnection,
+          );
+        }
+
         await playPromise;
       }
     } catch (error: unknown) {
       const failedTransitionStillOwnsDestination = this.getCurrent() === destinationSong
         && this.currentQueueEntryVersion === destinationQueueEntryVersion
-        && (destinationPlaybackAttemptVersion === null
-          || this.playbackAttemptVersion === destinationPlaybackAttemptVersion);
+        && (destinationPlayback === null || this.playbackAttempts.owns(destinationPlayback));
       if (failedTransitionStillOwnsDestination) {
         this.queuePosition = originalQueuePosition;
         this.currentQueueEntryVersion = originalQueueEntryVersion;
@@ -458,14 +446,14 @@ export default class {
     return this.voiceActivityVolumeTarget ?? this.volume ?? this.defaultVolume;
   }
 
-  private async seekWithAttempt(positionSeconds: number, playbackAttemptVersion: number): Promise<void> {
+  private async seekWithAttempt(positionSeconds: number, attempt: PlaybackAttemptToken): Promise<void> {
     this.status = STATUS.PAUSED;
 
     const currentSong = this.getCurrent();
     const currentQueueEntryVersion = this.getCurrentQueueEntryId();
     const voiceConnection = await this.ensureVoiceConnectionReady();
 
-    if (!this.isPlaybackAttemptCurrent(playbackAttemptVersion, voiceConnection)) {
+    if (!this.playbackAttempts.isCurrent(attempt, voiceConnection)) {
       return;
     }
 
@@ -473,8 +461,17 @@ export default class {
       throw new Error('No song currently playing');
     }
 
-    if (currentQueueEntryVersion === null
-      || !this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+    if (currentQueueEntryVersion === null) {
+      return;
+    }
+
+    const playback = this.playbackAttempts.capture(
+      attempt,
+      currentSong,
+      currentQueueEntryVersion,
+      voiceConnection,
+    );
+    if (!this.playbackAttempts.owns(playback)) {
       return;
     }
 
@@ -490,7 +487,7 @@ export default class {
     }
 
     const stream = await this.getStream(currentSong, {seek: realPositionSeconds, to});
-    if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+    if (!this.playbackAttempts.owns(playback)) {
       this.destroyStaleStream(stream);
       return;
     }
@@ -511,12 +508,12 @@ export default class {
     this.nowPlayingQueueEntryVersion = currentQueueEntryVersion;
   }
 
-  private async playWithAttempt(playbackAttemptVersion: number, allowAgeRestrictedFallback: boolean): Promise<void> {
+  private async playWithAttempt(attempt: PlaybackAttemptToken, allowAgeRestrictedFallback: boolean): Promise<void> {
     const currentSong = this.getCurrent();
     const currentQueueEntryVersion = this.getCurrentQueueEntryId();
     const voiceConnection = await this.ensureVoiceConnectionReady();
 
-    if (!this.isPlaybackAttemptCurrent(playbackAttemptVersion, voiceConnection)) {
+    if (!this.playbackAttempts.isCurrent(attempt, voiceConnection)) {
       return;
     }
 
@@ -524,8 +521,17 @@ export default class {
       throw new Error('Queue empty.');
     }
 
-    if (currentQueueEntryVersion === null
-      || !this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+    if (currentQueueEntryVersion === null) {
+      return;
+    }
+
+    const playback = this.playbackAttempts.capture(
+      attempt,
+      currentSong,
+      currentQueueEntryVersion,
+      voiceConnection,
+    );
+    if (!this.playbackAttempts.owns(playback)) {
       return;
     }
 
@@ -548,7 +554,7 @@ export default class {
 
       // Was disconnected, need to recreate stream
       if (!currentSong.isLive) {
-        return this.seekWithAttempt(this.getPosition(), playbackAttemptVersion);
+        return this.seekWithAttempt(this.getPosition(), attempt);
       }
     }
 
@@ -561,7 +567,7 @@ export default class {
       }
 
       const stream = await this.getStream(currentSong, {seek: positionSeconds, to});
-      if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+      if (!this.playbackAttempts.owns(playback)) {
         this.destroyStaleStream(stream);
         return;
       }
@@ -584,7 +590,7 @@ export default class {
     } catch (error: unknown) {
       await this.handlePlaybackError(
         error,
-        {currentSong, currentQueueEntryVersion, playbackAttemptVersion, voiceConnection},
+        playback,
         allowAgeRestrictedFallback,
       );
     }
@@ -592,16 +598,10 @@ export default class {
 
   private async handlePlaybackError(
     error: unknown,
-    playback: {
-      currentSong: QueuedSong;
-      currentQueueEntryVersion: number;
-      playbackAttemptVersion: number;
-      voiceConnection: VoiceConnection;
-    },
+    playback: PlayerPlaybackAttemptContext,
     allowAgeRestrictedFallback: boolean,
   ): Promise<void> {
-    const {currentSong, currentQueueEntryVersion, playbackAttemptVersion, voiceConnection} = playback;
-    if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+    if (!this.playbackAttempts.owns(playback)) {
       throw error;
     }
 
@@ -613,17 +613,12 @@ export default class {
     if (error instanceof YtDlpMediaUnavailableError
       && error.reason === 'age-restricted'
       && allowAgeRestrictedFallback) {
-      const fallbackHandled = await this.tryAgeRestrictedAudioFallback(
-        currentSong,
-        currentQueueEntryVersion,
-        playbackAttemptVersion,
-        voiceConnection,
-      );
+      const fallbackHandled = await this.tryAgeRestrictedAudioFallback(playback);
       if (fallbackHandled) {
         return;
       }
 
-      if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, currentSong, currentQueueEntryVersion, voiceConnection)) {
+      if (!this.playbackAttempts.owns(playback)) {
         throw error;
       }
     }
@@ -746,81 +741,16 @@ export default class {
   }
 
   private async onVoiceConnectionDisconnect(voiceConnection: VoiceConnection): Promise<void> {
-    if (this.voiceConnection !== voiceConnection) {
-      this.destroyVoiceConnection(voiceConnection);
-      return;
-    }
-
-    if (voiceConnection.state.status !== VoiceConnectionStatus.Disconnected) {
-      if (voiceConnection.state.status === VoiceConnectionStatus.Destroyed) {
-        this.disconnect();
-      }
-
-      return;
-    }
-
-    const disconnectedState = voiceConnection.state;
-    if (disconnectedState.reason === VoiceConnectionDisconnectReason.WebSocketClose && disconnectedState.closeCode === 4014) {
-      try {
-        await Promise.race([
-          entersState(voiceConnection, VoiceConnectionStatus.Connecting, 5_000),
-          entersState(voiceConnection, VoiceConnectionStatus.Signalling, 5_000),
-        ]);
-        if (this.voiceConnection !== voiceConnection) {
-          this.destroyVoiceConnection(voiceConnection);
-        } else if (this.getVoiceConnectionStatus(voiceConnection) === VoiceConnectionStatus.Destroyed) {
-          this.disconnect();
-        }
-
-        return;
-      } catch {
-        if (this.voiceConnection === voiceConnection) {
+    await recoverVoiceConnection(voiceConnection, {
+      isCurrent: candidate => this.voiceConnection === candidate,
+      dispose: candidate => {
+        if (this.voiceConnection === candidate) {
           this.disconnect();
         } else {
-          this.destroyVoiceConnection(voiceConnection);
+          destroyVoiceConnection(candidate);
         }
-
-        return;
-      }
-    }
-
-    if (voiceConnection.rejoinAttempts < 5) {
-      await sleep((voiceConnection.rejoinAttempts + 1) * 5_000);
-
-      if (this.voiceConnection !== voiceConnection) {
-        this.destroyVoiceConnection(voiceConnection);
-        return;
-      }
-
-      const connectionStatus = this.getVoiceConnectionStatus(voiceConnection);
-      if (connectionStatus !== VoiceConnectionStatus.Disconnected) {
-        if (connectionStatus === VoiceConnectionStatus.Destroyed) {
-          this.disconnect();
-        }
-
-        return;
-      }
-
-      if (voiceConnection.rejoin()) {
-        return;
-      }
-    }
-
-    if (this.voiceConnection === voiceConnection) {
-      this.disconnect();
-    } else {
-      this.destroyVoiceConnection(voiceConnection);
-    }
-  }
-
-  private destroyVoiceConnection(voiceConnection: VoiceConnection): void {
-    if (voiceConnection.state.status !== VoiceConnectionStatus.Destroyed) {
-      voiceConnection.destroy();
-    }
-  }
-
-  private getVoiceConnectionStatus(voiceConnection: VoiceConnection): VoiceConnectionStatus {
-    return voiceConnection.state.status;
+      },
+    });
   }
 
   private async ensureVoiceConnectionReady(): Promise<VoiceConnection> {
@@ -848,17 +778,13 @@ export default class {
     await this.play();
   }
 
-  private async tryAgeRestrictedAudioFallback(
-    song: QueuedSong,
-    queueEntryVersion: number,
-    playbackAttemptVersion: number,
-    voiceConnection: VoiceConnection,
-  ): Promise<boolean> {
+  private async tryAgeRestrictedAudioFallback(playback: PlayerPlaybackAttemptContext): Promise<boolean> {
+    const {song, queueEntryVersion, attempt, connection} = playback;
     if (!this.ageRestrictedFallbackResolver || song.source !== MediaSource.Youtube) {
       return false;
     }
 
-    if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, song, queueEntryVersion, voiceConnection)) {
+    if (!this.playbackAttempts.owns(playback)) {
       return true;
     }
 
@@ -866,7 +792,7 @@ export default class {
     try {
       fallback = await this.ageRestrictedFallbackResolver(song);
     } catch {
-      if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, song, queueEntryVersion, voiceConnection)) {
+      if (!this.playbackAttempts.owns(playback)) {
         return true;
       }
 
@@ -874,7 +800,7 @@ export default class {
       return false;
     }
 
-    if (!this.isPlaybackAttemptOwner(playbackAttemptVersion, song, queueEntryVersion, voiceConnection)) {
+    if (!this.playbackAttempts.owns(playback)) {
       return true;
     }
 
@@ -890,13 +816,19 @@ export default class {
       requestedBy: song.requestedBy,
     };
     this.queue[queuePosition] = replacement;
+    const replacementPlayback = this.playbackAttempts.capture(
+      attempt,
+      replacement,
+      queueEntryVersion,
+      connection,
+    );
     console.warn(`Trying audio fallback for age-restricted YouTube track in guild ${this.guildId}: ${song.url} -> ${replacement.url}`);
 
     try {
-      await this.playWithAttempt(playbackAttemptVersion, false);
+      await this.playWithAttempt(attempt, false);
       return true;
     } catch (error: unknown) {
-      if (this.isPlaybackAttemptOwner(playbackAttemptVersion, replacement, queueEntryVersion, voiceConnection)
+      if (this.playbackAttempts.owns(replacementPlayback)
         && this.queue[queuePosition] === replacement) {
         this.queue[queuePosition] = song;
       }
@@ -947,7 +879,7 @@ export default class {
   }
 
   private async finishQueue(): Promise<void> {
-    this.invalidatePlaybackAttempts();
+    this.playbackAttempts.invalidate();
     this.stopTrackingPosition();
     this.status = STATUS.IDLE;
     this.stopAudioPlayer(true);
@@ -1045,34 +977,6 @@ export default class {
 
     this.programmaticallyStoppedAudioPlayers.add(this.audioPlayer);
     this.audioPlayer.stop(force);
-  }
-
-  private beginPlaybackAttempt(): number {
-    this.playbackAttemptVersion++;
-    return this.playbackAttemptVersion;
-  }
-
-  private invalidatePlaybackAttempts(): void {
-    this.playbackAttemptVersion++;
-  }
-
-  private isPlaybackAttemptOwner(
-    playbackAttemptVersion: number,
-    song: QueuedSong,
-    queueEntryVersion: number,
-    voiceConnection: VoiceConnection,
-  ): boolean {
-    return this.isPlaybackAttemptCurrent(playbackAttemptVersion, voiceConnection)
-      && this.getCurrent() === song
-      && this.currentQueueEntryVersion === queueEntryVersion;
-  }
-
-  private isPlaybackAttemptCurrent(
-    playbackAttemptVersion: number,
-    voiceConnection: VoiceConnection,
-  ): boolean {
-    return this.playbackAttemptVersion === playbackAttemptVersion
-      && this.voiceConnection === voiceConnection;
   }
 
   private destroyStaleStream(stream: Readable): void {

--- a/src/services/spotify-api.ts
+++ b/src/services/spotify-api.ts
@@ -22,7 +22,19 @@ export default class {
 
   async getAlbum(url: string, playlistLimit: number): Promise<[SpotifyTrack[], QueuedPlaylist]> {
     const uri = spotifyURI.parse(url) as spotifyURI.Album;
-    const [{body: album}, {body: {items}}] = await Promise.all([this.spotify.getAlbum(uri.id), this.spotify.getAlbumTracks(uri.id, {limit: 50})]);
+    let [{body: album}, {body: tracksResponse}] = await Promise.all([this.spotify.getAlbum(uri.id), this.spotify.getAlbumTracks(uri.id, {limit: 50})]);
+    const items = [...tracksResponse.items];
+
+    while (tracksResponse.next) {
+      // eslint-disable-next-line no-await-in-loop
+      ({body: tracksResponse} = await this.spotify.getAlbumTracks(uri.id, {
+        limit: parseInt(new URL(tracksResponse.next).searchParams.get('limit') ?? '50', 10),
+        offset: parseInt(new URL(tracksResponse.next).searchParams.get('offset') ?? '0', 10),
+      }));
+
+      items.push(...tracksResponse.items);
+    }
+
     const tracks = this.limitTracks(items, playlistLimit).map(this.toSpotifyTrack);
     const playlist = {title: album.name, source: album.href};
 

--- a/src/services/voice-connection-recovery.ts
+++ b/src/services/voice-connection-recovery.ts
@@ -1,0 +1,100 @@
+import {setTimeout as sleep} from 'timers/promises';
+import {
+  entersState,
+  VoiceConnection,
+  VoiceConnectionDisconnectReason,
+  VoiceConnectionStatus,
+} from '@discordjs/voice';
+
+export interface VoiceConnectionRecoveryRuntime {
+  waitForState(
+    connection: VoiceConnection,
+    status: VoiceConnectionStatus,
+    timeout: number,
+  ): Promise<unknown>;
+  sleep(delay: number): Promise<unknown>;
+}
+
+export interface VoiceConnectionRecoveryOptions {
+  runtime?: VoiceConnectionRecoveryRuntime;
+  isCurrent(connection: VoiceConnection): boolean;
+  dispose(connection: VoiceConnection): void;
+}
+
+const defaultRuntime: VoiceConnectionRecoveryRuntime = {
+  waitForState: async (connection, status, timeout) => {
+    await entersState(connection, status, timeout);
+  },
+  sleep,
+};
+
+const getVoiceConnectionStatus = (connection: VoiceConnection): VoiceConnectionStatus => (
+  connection.state.status
+);
+
+export function destroyVoiceConnection(connection: VoiceConnection): void {
+  if (connection.state.status !== VoiceConnectionStatus.Destroyed) {
+    connection.destroy();
+  }
+}
+
+export async function recoverVoiceConnection(
+  connection: VoiceConnection,
+  {isCurrent, dispose, runtime = defaultRuntime}: VoiceConnectionRecoveryOptions,
+): Promise<void> {
+  if (!isCurrent(connection)) {
+    dispose(connection);
+    return;
+  }
+
+  if (connection.state.status !== VoiceConnectionStatus.Disconnected) {
+    if (connection.state.status === VoiceConnectionStatus.Destroyed) {
+      dispose(connection);
+    }
+
+    return;
+  }
+
+  const disconnectedState = connection.state;
+  if (disconnectedState.reason === VoiceConnectionDisconnectReason.WebSocketClose
+    && disconnectedState.closeCode === 4014) {
+    try {
+      await Promise.race([
+        runtime.waitForState(connection, VoiceConnectionStatus.Connecting, 5_000),
+        runtime.waitForState(connection, VoiceConnectionStatus.Signalling, 5_000),
+      ]);
+      if (!isCurrent(connection) || getVoiceConnectionStatus(connection) === VoiceConnectionStatus.Destroyed) {
+        dispose(connection);
+      }
+
+      return;
+    } catch {
+      dispose(connection);
+      return;
+    }
+  }
+
+  if (connection.rejoinAttempts < 5) {
+    await runtime.sleep((connection.rejoinAttempts + 1) * 5_000);
+
+    if (!isCurrent(connection)) {
+      dispose(connection);
+      return;
+    }
+
+    const connectionStatus = getVoiceConnectionStatus(connection);
+    if (connectionStatus !== VoiceConnectionStatus.Disconnected) {
+      if (connectionStatus === VoiceConnectionStatus.Destroyed) {
+        dispose(connection);
+      }
+
+      return;
+    }
+
+    if (connection.rejoin()) {
+      return;
+    }
+  }
+
+  dispose(connection);
+}

--- a/src/services/youtube-api.ts
+++ b/src/services/youtube-api.ts
@@ -288,7 +288,7 @@ export default class {
       }
 
       if (!foundFirstTimestamp) {
-        if (timestamps[0][0] === '0:00' || timestamps[0][0] === '00:00') {
+        if (/^0+(?::0+)+$/u.test(timestamps[0][0])) {
           foundFirstTimestamp = true;
         } else {
           return null;

--- a/src/services/youtube-api.ts
+++ b/src/services/youtube-api.ts
@@ -169,10 +169,15 @@ export default class {
     const playlistVideos: PlaylistItem[] = [];
     const videoDetailsPromises: Array<Promise<void>> = [];
     const videoDetails: VideoDetailsResponse[] = [];
+    const requestedPageTokens = new Set<string>();
 
     let nextToken: string | undefined;
 
-    while (playlistVideos.length < playlist.contentDetails.itemCount) {
+    do {
+      if (nextToken) {
+        requestedPageTokens.add(nextToken);
+      }
+
       const playlistItemsParams = {
         searchParams: {
           part: 'id, contentDetails',
@@ -196,11 +201,13 @@ export default class {
 
       // Start fetching extra details about videos
       // PlaylistItem misses some details, eg. if the video is a livestream
-      videoDetailsPromises.push((async () => {
-        const videoDetailItems = await this.getVideosByID(items.map(item => item.contentDetails.videoId));
-        videoDetails.push(...videoDetailItems);
-      })());
-    }
+      if (items.length > 0) {
+        videoDetailsPromises.push((async () => {
+          const videoDetailItems = await this.getVideosByID(items.map(item => item.contentDetails.videoId));
+          videoDetails.push(...videoDetailItems);
+        })());
+      }
+    } while (nextToken && !requestedPageTokens.has(nextToken));
 
     await Promise.all(videoDetailsPromises);
 
@@ -270,7 +277,7 @@ export default class {
   }
 
   private parseChaptersFromDescription(description: string, videoDurationSeconds: number) {
-    const map = new Map<string, {offset: number; length: number}>();
+    const chapters: Array<[string, {offset: number; length: number}]> = [];
     let foundFirstTimestamp = false;
 
     const foundTimestamps: Array<{name: string; offset: number}> = [];
@@ -281,10 +288,10 @@ export default class {
       }
 
       if (!foundFirstTimestamp) {
-        if (/0{1,2}:00/.test(timestamps[0][0])) {
+        if (timestamps[0][0] === '0:00' || timestamps[0][0] === '00:00') {
           foundFirstTimestamp = true;
         } else {
-          continue;
+          return null;
         }
       }
 
@@ -295,20 +302,26 @@ export default class {
       foundTimestamps.push({name: chapterName, offset: seconds});
     }
 
+    const hasInvalidChapter = foundTimestamps.some(({name, offset}, index) => (
+      !name
+      || offset >= videoDurationSeconds
+      || (index > 0 && offset <= foundTimestamps[index - 1].offset)
+    ));
+
+    if (foundTimestamps.length === 0 || hasInvalidChapter) {
+      return null;
+    }
+
     for (const [i, {name, offset}] of foundTimestamps.entries()) {
-      map.set(name, {
+      chapters.push([name, {
         offset,
         length: i === foundTimestamps.length - 1
           ? videoDurationSeconds - offset
           : foundTimestamps[i + 1].offset - offset,
-      });
+      }]);
     }
 
-    if (!map.size) {
-      return null;
-    }
-
-    return map;
+    return chapters;
   }
 
   private async searchVideoIDs(query: string, options: {videoCategoryId?: string} = {}): Promise<string[]> {

--- a/src/services/youtube-api.ts
+++ b/src/services/youtube-api.ts
@@ -291,7 +291,7 @@ export default class {
         if (/^0+(?::0+)+$/u.test(timestamps[0][0])) {
           foundFirstTimestamp = true;
         } else {
-          return null;
+          continue;
         }
       }
 

--- a/src/utils/build-embed.ts
+++ b/src/utils/build-embed.ts
@@ -76,6 +76,10 @@ export const buildPlayingMessageEmbed = (player: Player): EmbedBuilder => {
 };
 
 export const buildQueueEmbed = (player: Player, page: number, pageSize: number): EmbedBuilder => {
+  if (page < 1) {
+    throw new Error('page must be at least 1');
+  }
+
   const currentlyPlaying = player.getCurrent();
 
   if (!currentlyPlaying) {
@@ -83,7 +87,7 @@ export const buildQueueEmbed = (player: Player, page: number, pageSize: number):
   }
 
   const queueSize = player.queueSize();
-  const maxQueuePage = Math.ceil((queueSize + 1) / pageSize);
+  const maxQueuePage = Math.max(1, Math.ceil(queueSize / pageSize));
 
   if (page > maxQueuePage) {
     throw new Error('the queue isn\'t that big');
@@ -132,4 +136,3 @@ export const buildQueueEmbed = (player: Player, page: number, pageSize: number):
 
   return message;
 };
-

--- a/src/utils/create-database-url.ts
+++ b/src/utils/create-database-url.ts
@@ -2,6 +2,20 @@ import {join} from 'path';
 
 export const createDatabasePath = (directory: string) => join(directory, 'db.sqlite');
 
+export const createDatabasePathFromUrl = (databaseUrl: string, platform = process.platform) => {
+  if (!databaseUrl.startsWith('file:')) {
+    throw new Error('SQLite DATABASE_URL must use the file: protocol');
+  }
+
+  const databasePath = databaseUrl.slice('file:'.length).split('?', 1)[0];
+
+  if (platform === 'win32') {
+    return databasePath.replaceAll(/\\\\/g, '\\');
+  }
+
+  return databasePath;
+};
+
 const createDatabaseUrl = (directory: string) => {
   const url = `file:${createDatabasePath(directory)}?socket_timeout=10&connection_limit=1`;
 

--- a/src/utils/duration-string-to-seconds.ts
+++ b/src/utils/duration-string-to-seconds.ts
@@ -1,21 +1,29 @@
 import parse from 'parse-duration';
 
+const numberPattern = '-?(?:\\d+(?:[,_]\\d+)*(?:\\.\\d*)?|\\.\\d+)(?:e[-+]?\\d+)?';
+const durationUnitPattern = '(?:nanoseconds?|ns|µs|μs|us|microseconds?|milliseconds?|ms|seconds?|secs?|sec|s|minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d|weeks?|wks?|wk|w|months?|b|years?|yrs?|yr|y)';
+const secondsPattern = new RegExp(`^${numberPattern}$`, 'i');
+const durationPattern = new RegExp(`^(?:${numberPattern}\\s*${durationUnitPattern}\\s*)+$`, 'iu');
+
 /**
  * Parse duration strings to seconds.
  * @param str any common duration format, like 1m or 1hr 30s. If the input is a number it's assumed to be in seconds.
  * @returns seconds
  */
-const durationStringToSeconds = (str: string) => {
-  let seconds;
-  const isInputSeconds = Boolean(/\d+$/.exec(str));
+const durationStringToSeconds = (str: string): number => {
+  const normalized = str.trim();
 
-  if (isInputSeconds) {
-    seconds = Number.parseInt(str, 10);
-  } else {
-    seconds = parse(str) / 1000;
+  if (secondsPattern.test(normalized)) {
+    const seconds = Number(normalized.replace(/[,_]/g, ''));
+    return Number.isFinite(seconds) ? seconds : Number.NaN;
   }
 
-  return seconds;
+  if (!durationPattern.test(normalized)) {
+    return Number.NaN;
+  }
+
+  const milliseconds = parse(normalized);
+  return Number.isFinite(milliseconds) ? milliseconds / 1000 : Number.NaN;
 };
 
 export default durationStringToSeconds;

--- a/src/utils/duration-string-to-seconds.ts
+++ b/src/utils/duration-string-to-seconds.ts
@@ -1,6 +1,6 @@
 import parse from 'parse-duration';
 
-const numberPattern = '-?(?:\\d+(?:[,_]\\d+)*(?:\\.\\d*)?|\\.\\d+)(?:e[-+]?\\d+)?';
+const numberPattern = '[+-]?(?:\\d+(?:[,_]\\d+)*(?:\\.\\d*)?|\\.\\d+)(?:e[-+]?\\d+)?';
 const durationUnitPattern = '(?:nanoseconds?|ns|µs|μs|us|microseconds?|milliseconds?|ms|seconds?|secs?|sec|s|minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d|weeks?|wks?|wk|w|months?|b|years?|yrs?|yr|y)';
 const secondsPattern = new RegExp(`^${numberPattern}$`, 'i');
 const durationPattern = new RegExp(`^(?:${numberPattern}\\s*${durationUnitPattern}\\s*)+$`, 'iu');

--- a/src/utils/get-progress-bar.ts
+++ b/src/utils/get-progress-bar.ts
@@ -1,5 +1,5 @@
 export default (width: number, progress: number): string => {
-  const dotPosition = Math.floor(width * progress);
+  const dotPosition = Math.max(0, Math.min(width - 1, Math.floor(width * progress)));
 
   let res = '';
 

--- a/src/utils/get-youtube-and-spotify-suggestions-for.ts
+++ b/src/utils/get-youtube-and-spotify-suggestions-for.ts
@@ -66,7 +66,7 @@ const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: Spoti
     const numOfSpotifySuggestions = Math.min(maxSpotifySuggestions, totalSpotifyResults);
 
     const maxSpotifyAlbums = Math.floor(numOfSpotifySuggestions / 2);
-    const numOfSpotifyAlbums = Math.min(maxSpotifyAlbums, spotifyResponse.albums?.items.length ?? 0);
+    const numOfSpotifyAlbums = Math.min(maxSpotifyAlbums, spotifyAlbums.length);
     const maxSpotifyTracks = numOfSpotifySuggestions - numOfSpotifyAlbums;
 
     // Make room for spotify results

--- a/src/utils/get-youtube-and-spotify-suggestions-for.ts
+++ b/src/utils/get-youtube-and-spotify-suggestions-for.ts
@@ -65,23 +65,34 @@ const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: Spoti
     const maxSpotifySuggestions = Math.floor(limit / 2);
     const numOfSpotifySuggestions = Math.min(maxSpotifySuggestions, totalSpotifyResults);
 
-    const maxSpotifyAlbums = Math.floor(numOfSpotifySuggestions / 2);
-    const numOfSpotifyAlbums = Math.min(maxSpotifyAlbums, spotifyAlbums.length);
-    const maxSpotifyTracks = numOfSpotifySuggestions - numOfSpotifyAlbums;
+    const preferredSpotifyAlbums = Math.floor(numOfSpotifySuggestions / 2);
+    let numOfSpotifyAlbums = Math.min(preferredSpotifyAlbums, spotifyAlbums.length);
+    const numOfSpotifyTracks = Math.min(
+      numOfSpotifySuggestions - numOfSpotifyAlbums,
+      spotifyTracks.length,
+    );
+    numOfSpotifyAlbums = Math.min(
+      spotifyAlbums.length,
+      numOfSpotifySuggestions - numOfSpotifyTracks,
+    );
+
+    const selectedSpotifyAlbums = spotifyAlbums.slice(0, numOfSpotifyAlbums);
+    const selectedSpotifyTracks = spotifyTracks.slice(0, numOfSpotifyTracks);
+    const actualSpotifySuggestions = selectedSpotifyAlbums.length + selectedSpotifyTracks.length;
 
     // Make room for spotify results
-    const maxYouTubeSuggestions = limit - numOfSpotifySuggestions;
+    const maxYouTubeSuggestions = limit - actualSpotifySuggestions;
     suggestions = suggestions.slice(0, maxYouTubeSuggestions);
 
     suggestions.push(
-      ...spotifyAlbums.slice(0, maxSpotifyAlbums).map(album => ({
+      ...selectedSpotifyAlbums.map(album => ({
         name: `Spotify: 💿 ${album.name}${album.artists.length > 0 ? ` - ${album.artists[0].name}` : ''}`,
         value: `spotify:album:${album.id}`,
       })),
     );
 
     suggestions.push(
-      ...spotifyTracks.slice(0, maxSpotifyTracks).map(track => ({
+      ...selectedSpotifyTracks.map(track => ({
         name: `Spotify: 🎵 ${track.name}${track.artists.length > 0 ? ` - ${track.artists[0].name}` : ''}`,
         value: `spotify:track:${track.id}`,
       })),

--- a/src/utils/run-migrations-and-start.ts
+++ b/src/utils/run-migrations-and-start.ts
@@ -1,0 +1,25 @@
+interface MigrationOrchestration {
+  databaseExists: () => Promise<boolean>;
+  deployMigrations: () => Promise<void>;
+  hasPrismaMigrations: () => Promise<boolean>;
+  migrationsApplied?: () => void;
+  resolveInitialMigration: () => Promise<void>;
+  startBot: () => Promise<void>;
+}
+
+export const runMigrationsAndStart = async ({
+  databaseExists,
+  deployMigrations,
+  hasPrismaMigrations,
+  migrationsApplied,
+  resolveInitialMigration,
+  startBot,
+}: MigrationOrchestration) => {
+  if (await databaseExists() && !(await hasPrismaMigrations())) {
+    await resolveInitialMigration();
+  }
+
+  await deployMigrations();
+  migrationsApplied?.();
+  await startBot();
+};

--- a/tests/add-query-to-queue.test.ts
+++ b/tests/add-query-to-queue.test.ts
@@ -1,0 +1,316 @@
+import 'reflect-metadata';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const dependencyMocks = vi.hoisted(() => ({
+  buildPlayingMessageEmbed: vi.fn(() => ({title: 'playing'})),
+  getGuildSettings: vi.fn(),
+  getMemberVoiceChannel: vi.fn(),
+  getMostPopularVoiceChannel: vi.fn(),
+}));
+
+vi.mock('../src/utils/build-embed.js', () => ({
+  buildPlayingMessageEmbed: dependencyMocks.buildPlayingMessageEmbed,
+}));
+
+vi.mock('../src/utils/get-guild-settings.js', () => ({
+  getGuildSettings: dependencyMocks.getGuildSettings,
+}));
+
+vi.mock('../src/utils/channels.js', () => ({
+  getMemberVoiceChannel: dependencyMocks.getMemberVoiceChannel,
+  getMostPopularVoiceChannel: dependencyMocks.getMostPopularVoiceChannel,
+}));
+
+import AddQueryToQueue from '../src/services/add-query-to-queue.js';
+import Player, {MediaSource, QueuedSong, SongMetadata, STATUS} from '../src/services/player.js';
+
+const GUILD_ID = 'guild-id';
+
+const makeSong = (title: string, overrides: Partial<SongMetadata> = {}): SongMetadata => ({
+  title,
+  artist: 'Artist',
+  url: title.toLowerCase().replaceAll(' ', '-'),
+  length: 100,
+  offset: 0,
+  playlist: null,
+  isLive: false,
+  thumbnailUrl: null,
+  source: MediaSource.Youtube,
+  ...overrides,
+});
+
+const makeQueuedSong = (title: string, overrides: Partial<SongMetadata> = {}): QueuedSong => ({
+  ...makeSong(title, overrides),
+  addedInChannelId: 'text-channel-id',
+  requestedBy: 'requester-id',
+});
+
+const makeInteraction = () => ({
+  guild: {id: GUILD_ID},
+  member: {user: {id: 'requester-id'}},
+  channel: {id: 'text-channel-id'},
+  deferReply: vi.fn().mockResolvedValue(undefined),
+  editReply: vi.fn().mockResolvedValue(undefined),
+});
+
+const makeService = ({
+  player,
+  songs = [makeSong('New song')],
+  extraMessage = '',
+  cacheWrap,
+}: {
+  player: object;
+  songs?: SongMetadata[];
+  extraMessage?: string;
+  cacheWrap?: (fetchValue: () => Promise<unknown>) => Promise<unknown>;
+}) => {
+  const getSongs = {
+    getSongs: vi.fn().mockResolvedValue([songs, extraMessage]),
+  };
+  const playerManager = {
+    get: vi.fn(() => player),
+  };
+  const config = {
+    ENABLE_SPONSORBLOCK: false,
+    SPONSORBLOCK_TIMEOUT: 5,
+  };
+  const cache = {
+    wrap: vi.fn(cacheWrap ?? (async (fetchValue: () => Promise<unknown>) => fetchValue())),
+  };
+
+  return {
+    cache,
+    service: new AddQueryToQueue(getSongs as never, playerManager as never, config as never, cache as never),
+  };
+};
+
+const addToQueue = async (
+  service: AddQueryToQueue,
+  interaction: ReturnType<typeof makeInteraction>,
+  {
+    immediate = false,
+    skip = false,
+  }: {immediate?: boolean; skip?: boolean} = {},
+) => service.addToQueue({
+  query: 'request',
+  addToFrontOfQueue: immediate,
+  shuffleAdditions: false,
+  shouldSplitChapters: true,
+  skipCurrentTrack: skip,
+  interaction: interaction as never,
+});
+
+const skipNonMusicSegments = (service: AddQueryToQueue, song: SongMetadata) => (
+  service as unknown as {
+    skipNonMusicSegments(input: SongMetadata): Promise<SongMetadata>;
+  }
+).skipNonMusicSegments(song);
+
+const setSponsorBlock = (
+  service: AddQueryToQueue,
+  getSegments: ReturnType<typeof vi.fn>,
+) => Object.assign(service, {
+  sponsorBlock: {getSegments},
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dependencyMocks.getGuildSettings.mockResolvedValue({
+    playlistLimit: 50,
+    queueAddResponseEphemeral: false,
+  });
+  dependencyMocks.getMemberVoiceChannel.mockReturnValue([{id: 'voice-channel-id'}]);
+  dependencyMocks.getMostPopularVoiceChannel.mockReturnValue([{id: 'fallback-voice-channel-id'}]);
+});
+
+describe('AddQueryToQueue skip semantics', () => {
+  it('keeps the newly requested song current on an empty player and does not claim a skip', async () => {
+    const queue: QueuedSong[] = [];
+    const player = {
+      voiceConnection: null as object | null,
+      status: STATUS.IDLE,
+      getCurrent: vi.fn(() => queue[0] ?? null),
+      add: vi.fn((song: QueuedSong) => queue.push(song)),
+      connect: vi.fn(async () => {
+        player.voiceConnection = {};
+      }),
+      play: vi.fn().mockResolvedValue(undefined),
+      forward: vi.fn().mockResolvedValue(undefined),
+    };
+    const {service} = makeService({player});
+    const interaction = makeInteraction();
+
+    await addToQueue(service, interaction, {skip: true});
+
+    expect(queue.map(song => song.title)).toEqual(['New song']);
+    expect(player.getCurrent()?.title).toBe('New song');
+    expect(player.forward).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenLastCalledWith('u betcha, **New song** added to the queue');
+  });
+
+  it('skips a pre-existing current track and reports the skip with correct spacing', async () => {
+    const queue = [makeQueuedSong('Existing song')];
+    const player = {
+      voiceConnection: {},
+      status: STATUS.PLAYING,
+      getCurrent: vi.fn(() => queue[0] ?? null),
+      add: vi.fn((song: QueuedSong) => queue.push(song)),
+      connect: vi.fn().mockResolvedValue(undefined),
+      play: vi.fn().mockResolvedValue(undefined),
+      forward: vi.fn().mockResolvedValue(undefined),
+    };
+    const {service} = makeService({player});
+    const interaction = makeInteraction();
+
+    await addToQueue(service, interaction, {skip: true});
+
+    expect(player.forward).toHaveBeenCalledWith(1);
+    expect(interaction.editReply).toHaveBeenLastCalledWith('u betcha, **New song** added to the queue and current track skipped');
+  });
+});
+
+describe('AddQueryToQueue immediate batch insertion', () => {
+  it('keeps the first song current and preserves the rest of an immediate batch on an empty player', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = {} as never;
+    player.status = STATUS.PLAYING;
+    const songs = [
+      makeSong('First requested'),
+      makeSong('Second requested'),
+      makeSong('Third requested'),
+    ];
+    const {service} = makeService({player, songs});
+
+    await addToQueue(service, makeInteraction(), {immediate: true});
+
+    expect(player.getCurrent()?.title).toBe('First requested');
+    expect(player.getQueue().map(song => song.title)).toEqual([
+      'Second requested',
+      'Third requested',
+    ]);
+  });
+
+  it('places a playlist-tagged batch immediately after current and before the old queue', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    player.add(makeQueuedSong('Current'));
+    player.add(makeQueuedSong('Old upcoming'));
+    player.voiceConnection = {} as never;
+    player.status = STATUS.PLAYING;
+    const playlist = {title: 'Playlist', source: 'playlist-id'};
+    const songs = [
+      makeSong('Playlist one', {playlist}),
+      makeSong('Playlist two', {playlist}),
+    ];
+    const {service} = makeService({player, songs});
+
+    await addToQueue(service, makeInteraction(), {immediate: true});
+
+    expect(player.getQueue().map(song => song.title)).toEqual([
+      'Playlist one',
+      'Playlist two',
+      'Old upcoming',
+    ]);
+  });
+
+  it('preserves split-chapter order when the whole batch is added immediately', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    player.add(makeQueuedSong('Current'));
+    player.add(makeQueuedSong('Old upcoming'));
+    player.voiceConnection = {} as never;
+    player.status = STATUS.PLAYING;
+    const songs = [
+      makeSong('Chapter one', {url: 'split-video', offset: 0, length: 30}),
+      makeSong('Chapter two', {url: 'split-video', offset: 30, length: 40}),
+      makeSong('Chapter three', {url: 'split-video', offset: 70, length: 30}),
+    ];
+    const {service} = makeService({player, songs});
+
+    await addToQueue(service, makeInteraction(), {immediate: true});
+
+    expect(player.getQueue().map(song => ({title: song.title, offset: song.offset}))).toEqual([
+      {title: 'Chapter one', offset: 0},
+      {title: 'Chapter two', offset: 30},
+      {title: 'Chapter three', offset: 70},
+      {title: 'Old upcoming', offset: 0},
+    ]);
+  });
+});
+
+describe('AddQueryToQueue SponsorBlock trimming', () => {
+  it('keeps the maximum end when an overlapping segment is contained by the previous one', async () => {
+    const player = {};
+    const {service} = makeService({player});
+    setSponsorBlock(service, vi.fn().mockResolvedValue([
+      {startTime: 0, endTime: 40},
+      {startTime: 10, endTime: 20},
+    ]));
+    const song = makeSong('Contained overlap');
+
+    await expect(skipNonMusicSegments(service, song)).resolves.toMatchObject({
+      offset: 40,
+      length: 60,
+    });
+  });
+
+  it('trims disjoint intro and outro segments exactly once each', async () => {
+    const player = {};
+    const {service} = makeService({player});
+    setSponsorBlock(service, vi.fn().mockResolvedValue([
+      {startTime: 0, endTime: 10},
+      {startTime: 90, endTime: 100},
+    ]));
+    const song = makeSong('Disjoint segments');
+
+    await expect(skipNonMusicSegments(service, song)).resolves.toMatchObject({
+      offset: 10,
+      length: 80,
+    });
+  });
+
+  it('does not subtract one full-length segment twice or produce a negative length', async () => {
+    const player = {};
+    const {service} = makeService({player});
+    setSponsorBlock(service, vi.fn().mockResolvedValue([
+      {startTime: 0, endTime: 100},
+    ]));
+    const song = makeSong('Full segment');
+
+    await expect(skipNonMusicSegments(service, song)).resolves.toMatchObject({
+      offset: 100,
+      length: 0,
+    });
+    expect(song.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns the song unchanged when the SponsorBlock provider fails', async () => {
+    const player = {};
+    const {service} = makeService({player});
+    setSponsorBlock(service, vi.fn().mockRejectedValue(new Error('provider unavailable')));
+    const song = makeSong('Provider failure');
+    const original = {...song};
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(skipNonMusicSegments(service, song)).resolves.toBe(song);
+    expect(song).toEqual(original);
+    warning.mockRestore();
+  });
+
+  it('backs off after a 504 and leaves later songs unchanged without another provider call', async () => {
+    const player = {};
+    const {service, cache} = makeService({player});
+    const getSegments = vi.fn().mockRejectedValue(new Error('504 Gateway Timeout'));
+    setSponsorBlock(service, getSegments);
+    const firstSong = makeSong('First failure');
+    const laterSong = makeSong('During backoff');
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(skipNonMusicSegments(service, firstSong)).resolves.toBe(firstSong);
+    await expect(skipNonMusicSegments(service, laterSong)).resolves.toBe(laterSong);
+
+    expect(firstSong).toEqual(makeSong('First failure'));
+    expect(laterSong).toEqual(makeSong('During backoff'));
+    expect(cache.wrap).toHaveBeenCalledTimes(1);
+    expect(getSegments).toHaveBeenCalledTimes(1);
+    warning.mockRestore();
+  });
+});

--- a/tests/add-query-to-queue.test.ts
+++ b/tests/add-query-to-queue.test.ts
@@ -53,19 +53,49 @@ const makeInteraction = () => ({
   editReply: vi.fn().mockResolvedValue(undefined),
 });
 
+const makePausedPlayer = (...songs: QueuedSong[]) => {
+  const player = new Player({} as never, GUILD_ID);
+  songs.forEach(song => player.add(song));
+  player.voiceConnection = {} as never;
+  player.status = STATUS.PAUSED;
+  return player;
+};
+
+const makePromiseBarrier = () => {
+  let markEntered!: () => void;
+  let release!: () => void;
+  const entered = new Promise<void>(resolve => {
+    markEntered = resolve;
+  });
+  const blocked = new Promise<void>(resolve => {
+    release = resolve;
+  });
+
+  return {
+    entered,
+    release,
+    wait: async () => {
+      markEntered();
+      await blocked;
+    },
+  };
+};
+
 const makeService = ({
   player,
   songs = [makeSong('New song')],
   extraMessage = '',
   cacheWrap,
+  getSongs,
 }: {
   player: object;
   songs?: SongMetadata[];
   extraMessage?: string;
   cacheWrap?: (fetchValue: () => Promise<unknown>) => Promise<unknown>;
+  getSongs?: ReturnType<typeof vi.fn>;
 }) => {
-  const getSongs = {
-    getSongs: vi.fn().mockResolvedValue([songs, extraMessage]),
+  const songProvider = {
+    getSongs: getSongs ?? vi.fn().mockResolvedValue([songs, extraMessage]),
   };
   const playerManager = {
     get: vi.fn(() => player),
@@ -80,7 +110,7 @@ const makeService = ({
 
   return {
     cache,
-    service: new AddQueryToQueue(getSongs as never, playerManager as never, config as never, cache as never),
+    service: new AddQueryToQueue(songProvider as never, playerManager as never, config as never, cache as never),
   };
 };
 
@@ -118,6 +148,7 @@ beforeEach(() => {
   dependencyMocks.getGuildSettings.mockResolvedValue({
     playlistLimit: 50,
     queueAddResponseEphemeral: false,
+    secondsToWaitAfterQueueEmpties: 0,
   });
   dependencyMocks.getMemberVoiceChannel.mockReturnValue([{id: 'voice-channel-id'}]);
   dependencyMocks.getMostPopularVoiceChannel.mockReturnValue([{id: 'fallback-voice-channel-id'}]);
@@ -130,6 +161,7 @@ describe('AddQueryToQueue skip semantics', () => {
       voiceConnection: null as object | null,
       status: STATUS.IDLE,
       getCurrent: vi.fn(() => queue[0] ?? null),
+      getCurrentQueueEntryId: vi.fn(() => queue.length === 0 ? null : 1),
       add: vi.fn((song: QueuedSong) => queue.push(song)),
       connect: vi.fn(async () => {
         player.voiceConnection = {};
@@ -142,30 +174,104 @@ describe('AddQueryToQueue skip semantics', () => {
 
     await addToQueue(service, interaction, {skip: true});
 
-    expect(queue.map(song => song.title)).toEqual(['New song']);
     expect(player.getCurrent()?.title).toBe('New song');
+    expect(player.connect).toHaveBeenCalledOnce();
+    expect(player.play).toHaveBeenCalledOnce();
     expect(player.forward).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenLastCalledWith('u betcha, **New song** added to the queue');
   });
 
   it('skips a pre-existing current track and reports the skip with correct spacing', async () => {
-    const queue = [makeQueuedSong('Existing song')];
-    const player = {
-      voiceConnection: {},
-      status: STATUS.PLAYING,
-      getCurrent: vi.fn(() => queue[0] ?? null),
-      add: vi.fn((song: QueuedSong) => queue.push(song)),
-      connect: vi.fn().mockResolvedValue(undefined),
-      play: vi.fn().mockResolvedValue(undefined),
-      forward: vi.fn().mockResolvedValue(undefined),
-    };
+    const player = makePausedPlayer(makeQueuedSong('Existing song'));
+    const forward = vi.spyOn(player, 'forward');
     const {service} = makeService({player});
     const interaction = makeInteraction();
 
     await addToQueue(service, interaction, {skip: true});
 
-    expect(player.forward).toHaveBeenCalledWith(1);
+    expect(forward).toHaveBeenCalledWith(1);
+    expect(player.getCurrent()?.title).toBe('New song');
     expect(interaction.editReply).toHaveBeenLastCalledWith('u betcha, **New song** added to the queue and current track skipped');
+  });
+
+  it('does not skip after the captured current entry advances while song lookup is blocked', async () => {
+    const player = makePausedPlayer(
+      makeQueuedSong('Captured current'),
+      makeQueuedSong('Already upcoming'),
+    );
+    const forward = vi.spyOn(player, 'forward');
+    const barrier = makePromiseBarrier();
+    const getSongs = vi.fn(async () => {
+      await barrier.wait();
+      return [[makeSong('New song')], ''];
+    });
+    const {service} = makeService({player, getSongs});
+    const interaction = makeInteraction();
+
+    const request = addToQueue(service, interaction, {skip: true});
+    await barrier.entered;
+    player.manualForward(1);
+    expect(player.getCurrent()?.title).toBe('Already upcoming');
+
+    barrier.release();
+    await request;
+
+    expect(player.getCurrent()?.title).toBe('Already upcoming');
+    expect(player.getQueue().map(song => song.title)).toEqual(['New song']);
+    expect(forward).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenLastCalledWith('u betcha, **New song** added to the queue');
+  });
+
+  it('does not skip the new current song after the captured entry disappears during song lookup', async () => {
+    const player = makePausedPlayer(makeQueuedSong('Captured current'));
+    const forward = vi.spyOn(player, 'forward');
+    const barrier = makePromiseBarrier();
+    const getSongs = vi.fn(async () => {
+      await barrier.wait();
+      return [[makeSong('New song')], ''];
+    });
+    const {service} = makeService({player, getSongs});
+    const interaction = makeInteraction();
+
+    const request = addToQueue(service, interaction, {skip: true});
+    await barrier.entered;
+    player.removeCurrent();
+    expect(player.getCurrent()).toBeNull();
+
+    barrier.release();
+    await request;
+
+    expect(player.getCurrent()?.title).toBe('New song');
+    expect(player.getQueue()).toEqual([]);
+    expect(forward).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenLastCalledWith('u betcha, **New song** added to the queue');
+  });
+
+  it('does not treat a looped reuse of the same song object as the captured queue entry', async () => {
+    const repeatedSong = makeQueuedSong('Repeated song');
+    const player = makePausedPlayer(repeatedSong);
+    const forward = vi.spyOn(player, 'forward');
+    const barrier = makePromiseBarrier();
+    const getSongs = vi.fn(async () => {
+      await barrier.wait();
+      return [[makeSong('New song')], ''];
+    });
+    const {service} = makeService({player, getSongs});
+    const interaction = makeInteraction();
+
+    const request = addToQueue(service, interaction, {skip: true});
+    await barrier.entered;
+    player.add(repeatedSong);
+    player.manualForward(1);
+    expect(player.getCurrent()).toBe(repeatedSong);
+
+    barrier.release();
+    await request;
+
+    expect(player.getCurrent()).toBe(repeatedSong);
+    expect(player.getQueue().map(song => song.title)).toEqual(['New song']);
+    expect(forward).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenLastCalledWith('u betcha, **New song** added to the queue');
   });
 });
 

--- a/tests/bot-lifecycle.test.ts
+++ b/tests/bot-lifecycle.test.ts
@@ -1,0 +1,468 @@
+import 'reflect-metadata';
+import {ActivityType, ChannelType, Collection} from 'discord.js';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const spinner = {
+    start: vi.fn(),
+    succeed: vi.fn(),
+    text: '',
+  };
+  spinner.start.mockReturnValue(spinner);
+
+  return {
+    containerGet: vi.fn(),
+    containerGetAll: vi.fn(),
+    debug: vi.fn(),
+    dependencyReport: vi.fn(() => 'dependency report'),
+    login: vi.fn(),
+    playerConstructions: [] as Array<{
+      fileCache: unknown;
+      findAudioFallback: (song: unknown) => Promise<unknown>;
+      guildId: string;
+    }>,
+    restPut: vi.fn(),
+    restSetToken: vi.fn(),
+    settingUpsert: vi.fn(),
+    spinner,
+    voiceStateHandler: vi.fn(),
+  };
+});
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => mocks.spinner),
+}));
+
+vi.mock('@discordjs/rest', () => ({
+  REST: class {
+    setToken(token: string) {
+      mocks.restSetToken(token);
+      return this;
+    }
+
+    put(route: string, options: unknown) {
+      return mocks.restPut(route, options);
+    }
+  },
+}));
+
+vi.mock('@discordjs/voice', () => ({
+  generateDependencyReport: mocks.dependencyReport,
+}));
+
+vi.mock('../src/inversify.config.js', () => ({
+  default: {
+    get: mocks.containerGet,
+    getAll: mocks.containerGetAll,
+  },
+}));
+
+vi.mock('../src/utils/db.js', () => ({
+  prisma: {
+    setting: {upsert: mocks.settingUpsert},
+  },
+}));
+
+vi.mock('../src/utils/debug.js', () => ({
+  default: mocks.debug,
+}));
+
+vi.mock('../src/events/voice-state-update.js', () => ({
+  default: mocks.voiceStateHandler,
+}));
+
+vi.mock('../src/services/player.js', () => ({
+  default: class {
+    readonly fileCache: unknown;
+    readonly findAudioFallback: (song: unknown) => Promise<unknown>;
+    readonly guildId: string;
+
+    constructor(fileCache: unknown, guildId: string, findAudioFallback: (song: unknown) => Promise<unknown>) {
+      this.fileCache = fileCache;
+      this.guildId = guildId;
+      this.findAudioFallback = findAudioFallback;
+      mocks.playerConstructions.push(this);
+    }
+  },
+}));
+
+import Bot from '../src/bot.js';
+import PlayerManager from '../src/managers/player.js';
+import {TYPES} from '../src/types.js';
+
+const COMMAND_NAMES = [
+  'clear',
+  'config',
+  'disconnect',
+  'favorites',
+  'fseek',
+  'loop-queue',
+  'loop',
+  'move',
+  'next',
+  'now-playing',
+  'pause',
+  'play',
+  'queue',
+  'remove',
+  'replay',
+  'resume',
+  'seek',
+  'shuffle',
+  'skip',
+  'stop',
+  'unskip',
+  'volume',
+] as const;
+
+type Handler = (...args: never[]) => unknown;
+
+interface StructuralCommand {
+  execute?: ReturnType<typeof vi.fn>;
+  requiresVC?: boolean | ((interaction: StructuralInteraction) => boolean);
+  slashCommand: {
+    name: string;
+    toJSON: ReturnType<typeof vi.fn>;
+  };
+}
+
+interface StructuralInteraction {
+  commandName: string;
+  deferred: boolean;
+  editReply: ReturnType<typeof vi.fn>;
+  guild: object | null;
+  isAutocomplete: () => boolean;
+  isButton: () => boolean;
+  isChatInputCommand: () => boolean;
+  isCommand: () => boolean;
+  member?: {user: {id: string}};
+  options: {getSubcommand: () => string};
+  replied: boolean;
+  reply: ReturnType<typeof vi.fn>;
+}
+
+const makeCommand = (name: string, overrides: Partial<StructuralCommand> = {}): StructuralCommand => ({
+  execute: vi.fn().mockResolvedValue(undefined),
+  slashCommand: {
+    name,
+    toJSON: vi.fn(() => ({description: `${name} command`, name})),
+  },
+  ...overrides,
+});
+
+const makeCommandSet = () => COMMAND_NAMES.map(name => makeCommand(name));
+
+const makeConfig = (registerCommandsOnBot: boolean, activityUrl = '') => ({
+  BOT_ACTIVITY: 'preservation music',
+  BOT_ACTIVITY_TYPE: ActivityType.Streaming,
+  BOT_ACTIVITY_URL: activityUrl,
+  BOT_STATUS: 'idle' as const,
+  DISCORD_TOKEN: 'fake-token',
+  REGISTER_COMMANDS_ON_BOT: registerCommandsOnBot,
+});
+
+const makeClient = (guildIds: string[] = []) => {
+  const handlers = new Map<string, Handler>();
+  const setPresence = vi.fn();
+  const client = {
+    guilds: {
+      cache: new Collection(guildIds.map(id => [id, {id}])),
+    },
+    login: mocks.login,
+    on: vi.fn((event: string, handler: Handler) => {
+      handlers.set(event, handler);
+      return client;
+    }),
+    once: vi.fn((event: string, handler: Handler) => {
+      handlers.set(event, handler);
+      return client;
+    }),
+    user: {
+      id: 'application-id',
+      setPresence,
+    },
+  };
+
+  return {client, handlers, setPresence};
+};
+
+const makeInteraction = (commandName: string, overrides: Partial<StructuralInteraction> = {}): StructuralInteraction => ({
+  commandName,
+  deferred: false,
+  editReply: vi.fn().mockResolvedValue(undefined),
+  guild: {channels: {cache: new Collection()}},
+  isAutocomplete: () => false,
+  isButton: () => false,
+  isChatInputCommand: () => true,
+  isCommand: () => true,
+  member: {user: {id: 'member-id'}},
+  options: {getSubcommand: () => 'list'},
+  replied: false,
+  reply: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const registerBot = async (registerCommandsOnBot: boolean, commands = makeCommandSet(), guildIds: string[] = []) => {
+  const config = makeConfig(registerCommandsOnBot, 'https://example.test/stream');
+  const clientState = makeClient(guildIds);
+
+  mocks.containerGetAll.mockReturnValue(commands);
+  mocks.containerGet.mockImplementation(type => {
+    if (type === TYPES.Config) {
+      return config;
+    }
+
+    if (type === TYPES.Client) {
+      return clientState.client;
+    }
+
+    throw new Error('unexpected container lookup');
+  });
+
+  const bot = new Bot(clientState.client as never, config as never);
+  await bot.register();
+
+  return {...clientState, commands, config};
+};
+
+const invoke = async (handlers: Map<string, Handler>, event: string, ...args: unknown[]) => {
+  const handler = handlers.get(event);
+  expect(handler).toBeTypeOf('function');
+  await handler!(...args as never[]);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.login.mockResolvedValue(undefined);
+  mocks.restPut.mockResolvedValue(undefined);
+  mocks.settingUpsert.mockResolvedValue({guildId: 'guild-new'});
+  mocks.spinner.text = '';
+  mocks.spinner.start.mockReturnValue(mocks.spinner);
+  mocks.playerConstructions.splice(0);
+});
+
+describe('Discord command registration and ready lifecycle', () => {
+  it('replaces global commands with the full command set in bot registration mode', async () => {
+    const {commands, handlers, setPresence} = await registerBot(true, makeCommandSet(), ['guild-a', 'guild-b']);
+
+    expect(mocks.login).toHaveBeenCalledOnce();
+    expect(mocks.login).toHaveBeenCalledWith();
+    await invoke(handlers, 'ready');
+
+    expect(mocks.restSetToken).toHaveBeenCalledWith('fake-token');
+    expect(mocks.restPut).toHaveBeenCalledOnce();
+    expect(mocks.restPut).toHaveBeenCalledWith('/applications/application-id/commands', {
+      body: commands.map(command => command.slashCommand.toJSON()),
+    });
+    expect(setPresence).toHaveBeenCalledAfter(mocks.restPut);
+  });
+
+  it('registers every cached guild and removes global commands in guild registration mode', async () => {
+    const {commands, handlers} = await registerBot(false, makeCommandSet(), ['guild-a', 'guild-b']);
+
+    await invoke(handlers, 'ready');
+
+    const body = commands.map(command => command.slashCommand.toJSON());
+    expect(mocks.restPut).toHaveBeenCalledTimes(3);
+    expect(mocks.restPut).toHaveBeenCalledWith('/applications/application-id/guilds/guild-a/commands', {body});
+    expect(mocks.restPut).toHaveBeenCalledWith('/applications/application-id/guilds/guild-b/commands', {body});
+    expect(mocks.restPut).toHaveBeenCalledWith('/applications/application-id/commands', {body: []});
+  });
+
+  it('applies configured presence and reports dependency diagnostics plus the invite link', async () => {
+    const {handlers, setPresence} = await registerBot(true);
+
+    await invoke(handlers, 'ready');
+
+    expect(mocks.dependencyReport).toHaveBeenCalledOnce();
+    expect(mocks.debug).toHaveBeenCalledWith('dependency report');
+    expect(setPresence).toHaveBeenCalledWith({
+      activities: [{
+        name: 'preservation music',
+        type: ActivityType.Streaming,
+        url: 'https://example.test/stream',
+      }],
+      status: 'idle',
+    });
+    expect(mocks.spinner.succeed).toHaveBeenCalledAfter(setPresence);
+    expect(mocks.spinner.succeed).toHaveBeenCalledWith('Ready! Invite the bot with https://discordapp.com/oauth2/authorize?client_id=application-id&scope=bot%20applications.commands&permissions=36700160');
+  });
+
+  it('omits an empty activity URL from presence', async () => {
+    const commands = makeCommandSet();
+    const config = makeConfig(true);
+    const {client, handlers, setPresence} = makeClient();
+    mocks.containerGetAll.mockReturnValue(commands);
+
+    await new Bot(client as never, config as never).register();
+    await invoke(handlers, 'ready');
+
+    expect(setPresence).toHaveBeenCalledWith(expect.objectContaining({
+      activities: [expect.objectContaining({url: undefined})],
+    }));
+  });
+
+  it('routes client errors to console and Discord debug events to the debug logger', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const {handlers} = await registerBot(true);
+    const clientError = new Error('client failure');
+
+    await invoke(handlers, 'error', clientError);
+    await invoke(handlers, 'debug', 'gateway trace');
+
+    expect(consoleError).toHaveBeenCalledWith(clientError);
+    expect(mocks.debug).toHaveBeenCalledWith('gateway trace');
+    consoleError.mockRestore();
+  });
+});
+
+describe('guild onboarding', () => {
+  it('creates guild settings, registers guild commands, and DMs the owner in guild mode', async () => {
+    const commands = makeCommandSet();
+    const {handlers} = await registerBot(false, commands);
+    const ownerSend = vi.fn().mockResolvedValue(undefined);
+    const guild = {
+      fetchOwner: vi.fn().mockResolvedValue({send: ownerSend}),
+      id: 'guild-new',
+    };
+
+    await invoke(handlers, 'guildCreate', guild);
+
+    expect(mocks.settingUpsert).toHaveBeenCalledWith({
+      create: {guildId: 'guild-new'},
+      update: {},
+      where: {guildId: 'guild-new'},
+    });
+    expect(mocks.restPut).toHaveBeenCalledWith('/applications/application-id/guilds/guild-new/commands', {
+      body: commands.map(command => command.slashCommand.toJSON()),
+    });
+    expect(guild.fetchOwner).toHaveBeenCalledOnce();
+    expect(ownerSend).toHaveBeenCalledWith(expect.stringContaining('https://github.com/museofficial/muse/wiki/Configuring-Bot-Permissions'));
+  });
+
+  it('skips guild command registration in global mode but still initializes and welcomes', async () => {
+    const {handlers} = await registerBot(true);
+    const ownerSend = vi.fn().mockResolvedValue(undefined);
+    const guild = {
+      fetchOwner: vi.fn().mockResolvedValue({send: ownerSend}),
+      id: 'guild-global',
+    };
+
+    await invoke(handlers, 'guildCreate', guild);
+
+    expect(mocks.settingUpsert).toHaveBeenCalledWith(expect.objectContaining({where: {guildId: 'guild-global'}}));
+    expect(mocks.restPut).not.toHaveBeenCalled();
+    expect(ownerSend).toHaveBeenCalledOnce();
+  });
+});
+
+describe('interaction boundaries', () => {
+  it('rejects chat-input commands used outside a guild', async () => {
+    const command = makeCommand('play');
+    const {handlers} = await registerBot(true, [command]);
+    const interaction = makeInteraction('play', {guild: null});
+
+    await invoke(handlers, 'interactionCreate', interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith('🚫 ope: you can\'t use this bot in a DM');
+    expect(command.execute).not.toHaveBeenCalled();
+  });
+
+  it('ephemerally rejects a voice-required command when the caller is outside voice', async () => {
+    const command = makeCommand('play', {requiresVC: true});
+    const {handlers} = await registerBot(true, [command]);
+    const interaction = makeInteraction('play');
+
+    await invoke(handlers, 'interactionCreate', interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: '🚫 ope: gotta be in a voice channel',
+      ephemeral: true,
+    });
+    expect(command.execute).not.toHaveBeenCalled();
+  });
+
+  it('allows a voice-required command when the caller is in any guild voice channel', async () => {
+    const command = makeCommand('play', {requiresVC: true});
+    const {handlers} = await registerBot(true, [command]);
+    const members = new Collection([['member-id', {id: 'member-id'}]]);
+    const guild = {
+      channels: {
+        cache: new Collection([['voice-id', {members, type: ChannelType.GuildVoice}]]),
+      },
+    };
+    const interaction = makeInteraction('play', {guild});
+
+    await invoke(handlers, 'interactionCreate', interaction);
+
+    expect(command.execute).toHaveBeenCalledWith(interaction);
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('evaluates conditional voice guards and leaves non-voice actions available', async () => {
+    const command = makeCommand('favorites', {
+      requiresVC: interaction => interaction.options.getSubcommand() === 'use',
+    });
+    const {handlers} = await registerBot(true, [command]);
+    const list = makeInteraction('favorites');
+    const use = makeInteraction('favorites', {options: {getSubcommand: () => 'use'}});
+
+    await invoke(handlers, 'interactionCreate', list);
+    await invoke(handlers, 'interactionCreate', use);
+
+    expect(command.execute).toHaveBeenCalledOnce();
+    expect(command.execute).toHaveBeenCalledWith(list);
+    expect(use.reply).toHaveBeenCalledWith({
+      content: '🚫 ope: gotta be in a voice channel',
+      ephemeral: true,
+    });
+  });
+
+  it('debug-logs command failures and sends a fresh ephemeral error response', async () => {
+    const failure = new Error('command failure');
+    const command = makeCommand('play', {execute: vi.fn().mockRejectedValue(failure)});
+    const {handlers} = await registerBot(true, [command]);
+    const interaction = makeInteraction('play');
+
+    await invoke(handlers, 'interactionCreate', interaction);
+
+    expect(mocks.debug).toHaveBeenCalledWith(failure);
+    expect(interaction.reply).toHaveBeenCalledWith({content: '🚫 ope: command failure', ephemeral: true});
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('edits deferred failures and swallows a failed error response', async () => {
+    const command = makeCommand('play', {execute: vi.fn().mockRejectedValue(new Error('command failure'))});
+    const {handlers} = await registerBot(true, [command]);
+    const interaction = makeInteraction('play', {
+      deferred: true,
+      editReply: vi.fn().mockRejectedValue(new Error('message deleted')),
+    });
+
+    await expect(invoke(handlers, 'interactionCreate', interaction)).resolves.toBeUndefined();
+
+    expect(interaction.editReply).toHaveBeenCalledWith('🚫 ope: command failure');
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+});
+
+describe('per-guild Player isolation', () => {
+  it('reuses one Player within a guild and creates a separate Player for another guild', async () => {
+    const fileCache = {kind: 'fake cache'};
+    const youtubeAPI = {findAudioFallback: vi.fn().mockResolvedValue({title: 'fallback'})};
+    const manager = new PlayerManager(fileCache as never, youtubeAPI as never);
+
+    const guildA = manager.get('guild-a');
+    const guildAAgain = manager.get('guild-a');
+    const guildB = manager.get('guild-b');
+
+    expect(guildAAgain).toBe(guildA);
+    expect(guildB).not.toBe(guildA);
+    expect(mocks.playerConstructions.map(player => player.guildId)).toEqual(['guild-a', 'guild-b']);
+    expect(mocks.playerConstructions.every(player => player.fileCache === fileCache)).toBe(true);
+
+    const song = {title: 'restricted'};
+    await mocks.playerConstructions[0].findAudioFallback(song);
+    expect(youtubeAPI.findAudioFallback).toHaveBeenCalledWith(song);
+  });
+});

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,0 +1,14 @@
+import {readFile} from 'node:fs/promises';
+import {describe, expect, it} from 'vitest';
+
+describe('GitHub test workflow', () => {
+  it('tests the exact minimum Node version and rolling Node 22', async () => {
+    const workflow = await readFile(new URL('../.github/workflows/test.yml', import.meta.url), 'utf8');
+    const matrixValues = workflow.match(/matrix:\s*\n\s+node-version:\s*\[([^\]]+)\]/u)?.[1]
+      .split(',')
+      .map(value => value.trim().replaceAll(/["']/g, ''));
+
+    expect(matrixValues).toEqual(['22.12.0', '22']);
+    expect(workflow).toContain('node-version: ${{ matrix.node-version }}');
+  });
+});

--- a/tests/command-boundaries.test.ts
+++ b/tests/command-boundaries.test.ts
@@ -293,6 +293,27 @@ describe('seek parsing', () => {
     expect(editReply).toHaveBeenCalledWith('👍 seeked to 00:00');
   });
 
+  it.each([
+    ['+1', 1],
+    ['+0:01', 1],
+  ])('keeps explicit-positive /seek value %s valid', async (value, expectedPosition) => {
+    let position = -1;
+    const player = {
+      getCurrent: () => ({length: 300, isLive: false}),
+      seek: vi.fn(async (nextPosition: number) => {
+        position = nextPosition;
+      }),
+      getPosition: () => position,
+    };
+    const {interaction, deferReply, editReply} = makeInteraction({strings: {time: value}});
+
+    await new Seek(managerFor(player) as never).execute(interaction);
+
+    expect(player.seek).toHaveBeenCalledWith(expectedPosition);
+    expect(deferReply).toHaveBeenCalledOnce();
+    expect(editReply).toHaveBeenCalledWith('👍 seeked to 00:01');
+  });
+
   it.each(['0', '-1', 'not-a-time', '1s trailing', '1e999s'])(
     '/fseek rejects non-positive or invalid value %s without side effects',
     async value => {
@@ -326,6 +347,24 @@ describe('seek parsing', () => {
     expect(player.forwardSeek).toHaveBeenCalledWith(15);
     expect(deferReply).toHaveBeenCalledOnce();
     expect(editReply).toHaveBeenCalledWith('👍 seeked to 00:25');
+  });
+
+  it('keeps explicit-positive /fseek +1s valid', async () => {
+    let position = 10;
+    const player = {
+      getCurrent: () => ({length: 300, isLive: false}),
+      getPosition: () => position,
+      forwardSeek: vi.fn(async (value: number) => {
+        position += value;
+      }),
+    };
+    const {interaction, deferReply, editReply} = makeInteraction({strings: {time: '+1s'}});
+
+    await new ForwardSeek(managerFor(player) as never).execute(interaction);
+
+    expect(player.forwardSeek).toHaveBeenCalledWith(1);
+    expect(deferReply).toHaveBeenCalledOnce();
+    expect(editReply).toHaveBeenCalledWith('👍 seeked to 00:11');
   });
 });
 

--- a/tests/command-boundaries.test.ts
+++ b/tests/command-boundaries.test.ts
@@ -258,7 +258,7 @@ describe('seek parsing', () => {
     expect(durationStringToSeconds('27,681 ns')).toBeCloseTo(0.000027681);
   });
 
-  it.each(['-1', 'not-a-time', '1:bad', '1s trailing', '1e999s'])(
+  it.each(['-1', '-0:01', '-00:30', 'not-a-time', '1:bad', '1s trailing', '1e999s'])(
     '/seek rejects invalid absolute value %s without side effects',
     async value => {
       const player = {
@@ -294,9 +294,10 @@ describe('seek parsing', () => {
   });
 
   it.each([
-    ['+1', 1],
-    ['+0:01', 1],
-  ])('keeps explicit-positive /seek value %s valid', async (value, expectedPosition) => {
+    ['+1', 1, '00:01'],
+    ['0:00', 0, '00:00'],
+    ['+0:01', 1, '00:01'],
+  ])('keeps supported signed or zero /seek value %s valid', async (value, expectedPosition, expectedTime) => {
     let position = -1;
     const player = {
       getCurrent: () => ({length: 300, isLive: false}),
@@ -311,7 +312,7 @@ describe('seek parsing', () => {
 
     expect(player.seek).toHaveBeenCalledWith(expectedPosition);
     expect(deferReply).toHaveBeenCalledOnce();
-    expect(editReply).toHaveBeenCalledWith('👍 seeked to 00:01');
+    expect(editReply).toHaveBeenCalledWith(`👍 seeked to ${expectedTime}`);
   });
 
   it.each(['0', '-1', 'not-a-time', '1s trailing', '1e999s'])(

--- a/tests/command-boundaries.test.ts
+++ b/tests/command-boundaries.test.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {PermissionFlagsBits} from 'discord.js';
 import type {ChatInputCommandInteraction} from 'discord.js';
 
 const mocks = vi.hoisted(() => ({
@@ -113,52 +114,160 @@ const makeInteraction = (options: {
 
 const managerFor = (player: object) => ({get: () => player});
 
+const COMMAND_NAMES = [
+  'clear',
+  'config',
+  'disconnect',
+  'favorites',
+  'fseek',
+  'loop-queue',
+  'loop',
+  'move',
+  'next',
+  'now-playing',
+  'pause',
+  'play',
+  'queue',
+  'remove',
+  'replay',
+  'resume',
+  'seek',
+  'shuffle',
+  'skip',
+  'stop',
+  'unskip',
+  'volume',
+] as const;
+
+const makeCommands = () => {
+  const playerManager = {} as never;
+  const addQueryToQueue = {} as never;
+
+  return [
+    new Clear(playerManager),
+    new Config(),
+    new Disconnect(playerManager),
+    new Favorites(addQueryToQueue),
+    new ForwardSeek(playerManager),
+    new LoopQueue(playerManager),
+    new Loop(playerManager),
+    new Move(playerManager),
+    new Next(playerManager),
+    new NowPlaying(playerManager),
+    new Pause(playerManager),
+    new Play(undefined as never, {} as never, addQueryToQueue),
+    new Queue(playerManager),
+    new Remove(playerManager),
+    new Replay(playerManager),
+    new Resume(playerManager),
+    new Seek(playerManager),
+    new Shuffle(playerManager),
+    new Skip(playerManager),
+    new Stop(playerManager),
+    new Unskip(playerManager),
+    new Volume(playerManager),
+  ];
+};
+
+interface SerializedOption {
+  max_value?: number;
+  min_value?: number;
+  name: string;
+  options?: SerializedOption[];
+}
+
+const findOption = (command: {options?: SerializedOption[]}, ...path: string[]): SerializedOption => {
+  let options = command.options;
+  let result: SerializedOption | undefined;
+
+  for (const name of path) {
+    result = options?.find(option => option.name === name);
+    expect(result, `missing command option ${path.join(' > ')}`).toBeDefined();
+    options = result?.options;
+  }
+
+  return result!;
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe('command metadata', () => {
-  it('serializes all 22 command builders', () => {
-    const playerManager = {} as never;
-    const addQueryToQueue = {} as never;
-    const commands = [
-      new Clear(playerManager),
-      new Config(),
-      new Disconnect(playerManager),
-      new Favorites(addQueryToQueue),
-      new ForwardSeek(playerManager),
-      new LoopQueue(playerManager),
-      new Loop(playerManager),
-      new Move(playerManager),
-      new Next(playerManager),
-      new NowPlaying(playerManager),
-      new Pause(playerManager),
-      new Play(undefined as never, {} as never, addQueryToQueue),
-      new Queue(playerManager),
-      new Remove(playerManager),
-      new Replay(playerManager),
-      new Resume(playerManager),
-      new Seek(playerManager),
-      new Shuffle(playerManager),
-      new Skip(playerManager),
-      new Stop(playerManager),
-      new Unskip(playerManager),
-      new Volume(playerManager),
-    ];
-
-    const serialized = commands.map(command => command.slashCommand.toJSON());
+  it('publishes the exact 22 unique command names', () => {
+    const serialized = makeCommands().map(command => command.slashCommand.toJSON());
+    const names = serialized.map(command => command.name);
 
     expect(serialized).toHaveLength(22);
-    expect(new Set(serialized.map(command => command.name))).toHaveLength(22);
+    expect(new Set(names)).toHaveLength(22);
+    expect([...names].sort()).toEqual([...COMMAND_NAMES].sort());
   });
 
-  it('publishes minimum values for queue and remove positions', () => {
-    const queue = new Queue({} as never).slashCommand.toJSON();
-    const remove = new Remove({} as never).slashCommand.toJSON();
+  it('preserves the audited voice-channel requirement matrix', () => {
+    const commandsByName = new Map(makeCommands().map(command => [
+      command.slashCommand.toJSON().name,
+      command as {requiresVC?: boolean | ((interaction: ChatInputCommandInteraction) => boolean)},
+    ]));
+    const alwaysRequiresVoice = [
+      'clear',
+      'disconnect',
+      'fseek',
+      'loop-queue',
+      'loop',
+      'next',
+      'pause',
+      'play',
+      'replay',
+      'resume',
+      'seek',
+      'shuffle',
+      'skip',
+      'stop',
+      'unskip',
+      'volume',
+    ];
+    const neverRequiresVoice = ['config', 'move', 'now-playing', 'queue', 'remove'];
 
-    expect(queue.options?.find(option => option.name === 'page')).toMatchObject({min_value: 1});
-    expect(remove.options?.find(option => option.name === 'position')).toMatchObject({min_value: 1});
-    expect(remove.options?.find(option => option.name === 'range')).toMatchObject({min_value: 1});
+    for (const name of alwaysRequiresVoice) {
+      expect(commandsByName.get(name)?.requiresVC, `/${name}`).toBe(true);
+    }
+
+    for (const name of neverRequiresVoice) {
+      expect(commandsByName.get(name)?.requiresVC, `/${name}`).toBeUndefined();
+    }
+
+    const favoritesGuard = commandsByName.get('favorites')?.requiresVC;
+    expect(favoritesGuard).toBeTypeOf('function');
+    const interactionFor = (subcommand: string) => ({
+      options: {getSubcommand: () => subcommand},
+    }) as unknown as ChatInputCommandInteraction;
+    expect((favoritesGuard as (interaction: ChatInputCommandInteraction) => boolean)(interactionFor('use'))).toBe(true);
+    expect((favoritesGuard as (interaction: ChatInputCommandInteraction) => boolean)(interactionFor('list'))).toBe(false);
+    expect((favoritesGuard as (interaction: ChatInputCommandInteraction) => boolean)(interactionFor('create'))).toBe(false);
+    expect((favoritesGuard as (interaction: ChatInputCommandInteraction) => boolean)(interactionFor('remove'))).toBe(false);
+  });
+
+  it('publishes the existing audited integer option bounds', () => {
+    const serialized = new Map(makeCommands().map(command => {
+      const json = command.slashCommand.toJSON();
+      return [json.name, json as unknown as {options?: SerializedOption[]}];
+    }));
+
+    expect(findOption(serialized.get('queue')!, 'page')).toMatchObject({min_value: 1});
+    expect(findOption(serialized.get('queue')!, 'page-size')).toMatchObject({min_value: 1, max_value: 30});
+    expect(findOption(serialized.get('remove')!, 'position')).toMatchObject({min_value: 1});
+    expect(findOption(serialized.get('remove')!, 'range')).toMatchObject({min_value: 1});
+    expect(findOption(serialized.get('volume')!, 'level')).toMatchObject({min_value: 0, max_value: 100});
+    expect(findOption(serialized.get('config')!, 'set-wait-after-queue-empties', 'delay')).toMatchObject({min_value: 0});
+    expect(findOption(serialized.get('config')!, 'set-reduce-vol-when-voice-target', 'volume')).toMatchObject({min_value: 0, max_value: 100});
+    expect(findOption(serialized.get('config')!, 'set-default-volume', 'level')).toMatchObject({min_value: 0, max_value: 100});
+    expect(findOption(serialized.get('config')!, 'set-default-queue-page-size', 'page-size')).toMatchObject({min_value: 1, max_value: 30});
+  });
+
+  it('limits /config to members with Manage Guild by default', () => {
+    const config = new Config().slashCommand.toJSON();
+
+    expect(config.default_member_permissions).toBe(PermissionFlagsBits.ManageGuild.toString());
   });
 });
 

--- a/tests/command-boundaries.test.ts
+++ b/tests/command-boundaries.test.ts
@@ -1,0 +1,385 @@
+import 'reflect-metadata';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {ChatInputCommandInteraction} from 'discord.js';
+
+const mocks = vi.hoisted(() => ({
+  getGuildSettings: vi.fn(),
+  settingUpdate: vi.fn(),
+}));
+
+vi.mock('../src/utils/get-guild-settings.js', () => ({
+  getGuildSettings: mocks.getGuildSettings,
+}));
+
+vi.mock('../src/utils/db.js', () => ({
+  prisma: {
+    setting: {update: mocks.settingUpdate},
+    favoriteQuery: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../src/services/player.js', () => ({
+  default: class {},
+  STATUS: {PLAYING: 0, PAUSED: 1, IDLE: 2},
+  MediaSource: {Youtube: 0, HLS: 1},
+  DEFAULT_VOLUME: 100,
+}));
+
+import Clear from '../src/commands/clear.js';
+import Config from '../src/commands/config.js';
+import Disconnect from '../src/commands/disconnect.js';
+import Favorites from '../src/commands/favorites.js';
+import ForwardSeek from '../src/commands/fseek.js';
+import LoopQueue from '../src/commands/loop-queue.js';
+import Loop from '../src/commands/loop.js';
+import Move from '../src/commands/move.js';
+import Next from '../src/commands/next.js';
+import NowPlaying from '../src/commands/now-playing.js';
+import Pause from '../src/commands/pause.js';
+import Play from '../src/commands/play.js';
+import Queue from '../src/commands/queue.js';
+import Remove from '../src/commands/remove.js';
+import Replay from '../src/commands/replay.js';
+import Resume from '../src/commands/resume.js';
+import Seek from '../src/commands/seek.js';
+import Shuffle from '../src/commands/shuffle.js';
+import Skip from '../src/commands/skip.js';
+import Stop from '../src/commands/stop.js';
+import Unskip from '../src/commands/unskip.js';
+import Volume from '../src/commands/volume.js';
+import {buildQueueEmbed} from '../src/utils/build-embed.js';
+import durationStringToSeconds from '../src/utils/duration-string-to-seconds.js';
+
+const STATUS = {PLAYING: 0, PAUSED: 1, IDLE: 2} as const;
+
+const makeSong = (index: number) => ({
+  title: `Song ${index}`,
+  artist: 'Artist',
+  url: `video${String(index).padStart(6, '0')}`,
+  length: 120,
+  offset: 0,
+  playlist: null,
+  isLive: false,
+  thumbnailUrl: null,
+  source: 0,
+  addedInChannelId: 'channel',
+  requestedBy: 'requester',
+});
+
+const makeQueuePlayer = (upcomingCount: number) => {
+  const upcoming = Array.from({length: upcomingCount}, (_, index) => makeSong(index + 2));
+
+  return {
+    status: STATUS.PAUSED,
+    loopCurrentSong: false,
+    loopCurrentQueue: false,
+    getCurrent: () => makeSong(1),
+    getQueue: () => upcoming,
+    queueSize: () => upcoming.length,
+    getPosition: () => 0,
+    getVolume: () => 100,
+  };
+};
+
+const makeInteraction = (options: {
+  integers?: Record<string, number | null>;
+  strings?: Record<string, string | null>;
+  subcommand?: string;
+} = {}) => {
+  const reply = vi.fn().mockResolvedValue(undefined);
+  const deferReply = vi.fn().mockResolvedValue(undefined);
+  const editReply = vi.fn().mockResolvedValue(undefined);
+
+  const interaction = {
+    guild: {id: 'guild'},
+    options: {
+      getInteger: vi.fn((name: string) => options.integers?.[name] ?? null),
+      getString: vi.fn((name: string) => options.strings?.[name] ?? null),
+      getBoolean: vi.fn(() => null),
+      getSubcommand: vi.fn(() => options.subcommand ?? ''),
+    },
+    reply,
+    deferReply,
+    editReply,
+  } as unknown as ChatInputCommandInteraction;
+
+  return {interaction, reply, deferReply, editReply};
+};
+
+const managerFor = (player: object) => ({get: () => player});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('command metadata', () => {
+  it('serializes all 22 command builders', () => {
+    const playerManager = {} as never;
+    const addQueryToQueue = {} as never;
+    const commands = [
+      new Clear(playerManager),
+      new Config(),
+      new Disconnect(playerManager),
+      new Favorites(addQueryToQueue),
+      new ForwardSeek(playerManager),
+      new LoopQueue(playerManager),
+      new Loop(playerManager),
+      new Move(playerManager),
+      new Next(playerManager),
+      new NowPlaying(playerManager),
+      new Pause(playerManager),
+      new Play(undefined as never, {} as never, addQueryToQueue),
+      new Queue(playerManager),
+      new Remove(playerManager),
+      new Replay(playerManager),
+      new Resume(playerManager),
+      new Seek(playerManager),
+      new Shuffle(playerManager),
+      new Skip(playerManager),
+      new Stop(playerManager),
+      new Unskip(playerManager),
+      new Volume(playerManager),
+    ];
+
+    const serialized = commands.map(command => command.slashCommand.toJSON());
+
+    expect(serialized).toHaveLength(22);
+    expect(new Set(serialized.map(command => command.name))).toHaveLength(22);
+  });
+
+  it('publishes minimum values for queue and remove positions', () => {
+    const queue = new Queue({} as never).slashCommand.toJSON();
+    const remove = new Remove({} as never).slashCommand.toJSON();
+
+    expect(queue.options?.find(option => option.name === 'page')).toMatchObject({min_value: 1});
+    expect(remove.options?.find(option => option.name === 'position')).toMatchObject({min_value: 1});
+    expect(remove.options?.find(option => option.name === 'range')).toMatchObject({min_value: 1});
+  });
+});
+
+describe('/queue', () => {
+  it('shows page 1 for a current-only queue', () => {
+    const embed = buildQueueEmbed(makeQueuePlayer(0) as never, 1, 10).toJSON();
+
+    expect(embed.fields?.find(field => field.name === 'Page')?.value).toBe('1 out of 1');
+  });
+
+  it('does not expose a phantom page for an exact multiple of upcoming tracks', () => {
+    const player = makeQueuePlayer(10);
+    const embed = buildQueueEmbed(player as never, 1, 10).toJSON();
+
+    expect(embed.fields?.find(field => field.name === 'Page')?.value).toBe('1 out of 1');
+    expect(() => buildQueueEmbed(player as never, 2, 10)).toThrow('the queue isn\'t that big');
+  });
+
+  it('rejects pages below 1 defensively', () => {
+    expect(() => buildQueueEmbed(makeQueuePlayer(1) as never, 0, 10)).toThrow('page must be at least 1');
+  });
+});
+
+describe('/remove', () => {
+  it('rejects a starting position beyond the upcoming queue without replying', async () => {
+    const upcoming = ['first', 'second'];
+    const player = {
+      queueSize: () => upcoming.length,
+      removeFromQueue: vi.fn((position: number, range: number) => upcoming.splice(position - 1, range)),
+    };
+    const {interaction, reply} = makeInteraction({integers: {position: 3, range: 1}});
+
+    await expect(new Remove(managerFor(player) as never).execute(interaction)).rejects.toThrow('position is outside the range of the queue');
+    expect(player.removeFromQueue).not.toHaveBeenCalled();
+    expect(upcoming).toEqual(['first', 'second']);
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it('removes the last valid upcoming position and replies', async () => {
+    const upcoming = ['first', 'second'];
+    const player = {
+      queueSize: () => upcoming.length,
+      removeFromQueue: vi.fn((position: number, range: number) => upcoming.splice(position - 1, range)),
+    };
+    const {interaction, reply} = makeInteraction({integers: {position: 2, range: 1}});
+
+    await new Remove(managerFor(player) as never).execute(interaction);
+
+    expect(upcoming).toEqual(['first']);
+    expect(reply).toHaveBeenCalledWith(':wastebasket: removed');
+  });
+});
+
+describe('/stop', () => {
+  for (const [name, status] of Object.entries(STATUS)) {
+    it(`stops, disconnects, and clears a connected ${name} session`, async () => {
+      const queue = ['current', 'upcoming'];
+      const player = {
+        status,
+        voiceConnection: {},
+        stop: vi.fn(() => {
+          player.voiceConnection = null as never;
+          queue.splice(0);
+        }),
+      };
+      const {interaction, reply} = makeInteraction();
+
+      await new Stop(managerFor(player) as never).execute(interaction);
+
+      expect(player.stop).toHaveBeenCalledOnce();
+      expect(player.voiceConnection).toBeNull();
+      expect(queue).toEqual([]);
+      expect(reply).toHaveBeenCalledWith('u betcha, stopped');
+    });
+  }
+
+  it('still rejects when there is no connection', async () => {
+    const player = {status: STATUS.PLAYING, voiceConnection: null, stop: vi.fn()};
+    const {interaction, reply} = makeInteraction();
+
+    await expect(new Stop(managerFor(player) as never).execute(interaction)).rejects.toThrow('not connected');
+    expect(player.stop).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+  });
+});
+
+describe('seek parsing', () => {
+  it('rejects duration strings with trailing junk or no duration', () => {
+    expect(durationStringToSeconds('1m trailing')).toBeNaN();
+    expect(durationStringToSeconds('not a duration')).toBeNaN();
+    expect(durationStringToSeconds('1e999s')).toBeNaN();
+  });
+
+  it('keeps valid numeric and compound durations', () => {
+    expect(durationStringToSeconds('0')).toBe(0);
+    expect(durationStringToSeconds('1m 30s')).toBe(90);
+    expect(durationStringToSeconds('27,681 ns')).toBeCloseTo(0.000027681);
+  });
+
+  it.each(['-1', 'not-a-time', '1:bad', '1s trailing', '1e999s'])(
+    '/seek rejects invalid absolute value %s without side effects',
+    async value => {
+      const player = {
+        getCurrent: () => ({length: 300, isLive: false}),
+        seek: vi.fn().mockResolvedValue(undefined),
+        getPosition: () => 0,
+      };
+      const {interaction, deferReply, editReply} = makeInteraction({strings: {time: value}});
+
+      await expect(new Seek(managerFor(player) as never).execute(interaction)).rejects.toThrow('invalid seek value');
+      expect(player.seek).not.toHaveBeenCalled();
+      expect(deferReply).not.toHaveBeenCalled();
+      expect(editReply).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps /seek 0 valid', async () => {
+    let position = -1;
+    const player = {
+      getCurrent: () => ({length: 300, isLive: false}),
+      seek: vi.fn(async (value: number) => {
+        position = value;
+      }),
+      getPosition: () => position,
+    };
+    const {interaction, deferReply, editReply} = makeInteraction({strings: {time: '0'}});
+
+    await new Seek(managerFor(player) as never).execute(interaction);
+
+    expect(player.seek).toHaveBeenCalledWith(0);
+    expect(deferReply).toHaveBeenCalledOnce();
+    expect(editReply).toHaveBeenCalledWith('👍 seeked to 00:00');
+  });
+
+  it.each(['0', '-1', 'not-a-time', '1s trailing', '1e999s'])(
+    '/fseek rejects non-positive or invalid value %s without side effects',
+    async value => {
+      const player = {
+        getCurrent: () => ({length: 300, isLive: false}),
+        getPosition: () => 10,
+        forwardSeek: vi.fn().mockResolvedValue(undefined),
+      };
+      const {interaction, deferReply, editReply} = makeInteraction({strings: {time: value}});
+
+      await expect(new ForwardSeek(managerFor(player) as never).execute(interaction)).rejects.toThrow('invalid seek value');
+      expect(player.forwardSeek).not.toHaveBeenCalled();
+      expect(deferReply).not.toHaveBeenCalled();
+      expect(editReply).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps a positive finite /fseek valid', async () => {
+    let position = 10;
+    const player = {
+      getCurrent: () => ({length: 300, isLive: false}),
+      getPosition: () => position,
+      forwardSeek: vi.fn(async (value: number) => {
+        position += value;
+      }),
+    };
+    const {interaction, deferReply, editReply} = makeInteraction({strings: {time: '15'}});
+
+    await new ForwardSeek(managerFor(player) as never).execute(interaction);
+
+    expect(player.forwardSeek).toHaveBeenCalledWith(15);
+    expect(deferReply).toHaveBeenCalledOnce();
+    expect(editReply).toHaveBeenCalledWith('👍 seeked to 00:25');
+  });
+});
+
+describe('/loop-queue', () => {
+  it('accepts current plus one upcoming song', async () => {
+    const player = {
+      status: STATUS.PAUSED,
+      queueSize: () => 1,
+      loopCurrentSong: true,
+      loopCurrentQueue: false,
+    };
+    const {interaction, reply} = makeInteraction();
+
+    await new LoopQueue(managerFor(player) as never).execute(interaction);
+
+    expect(player.loopCurrentSong).toBe(false);
+    expect(player.loopCurrentQueue).toBe(true);
+    expect(reply).toHaveBeenCalledWith('looped queue :)');
+  });
+
+  it('rejects when there is no upcoming song', async () => {
+    const player = {
+      status: STATUS.PAUSED,
+      queueSize: () => 0,
+      loopCurrentSong: false,
+      loopCurrentQueue: false,
+    };
+    const {interaction, reply} = makeInteraction();
+
+    await expect(new LoopQueue(managerFor(player) as never).execute(interaction)).rejects.toThrow('not enough songs to loop a queue!');
+    expect(reply).not.toHaveBeenCalled();
+  });
+});
+
+describe('/config get', () => {
+  it('shows requester-only responses and the voice reduction target from their own settings', async () => {
+    mocks.getGuildSettings.mockResolvedValue({
+      playlistLimit: 20,
+      secondsToWaitAfterQueueEmpties: 30,
+      leaveIfNoListeners: true,
+      autoAnnounceNextSong: false,
+      queueAddResponseEphemeral: true,
+      defaultVolume: 80,
+      defaultQueuePageSize: 10,
+      turnDownVolumeWhenPeopleSpeak: true,
+      turnDownVolumeWhenPeopleSpeakTarget: 23,
+    });
+    const {interaction, reply} = makeInteraction({subcommand: 'get'});
+
+    await new Config().execute(interaction);
+
+    const response = reply.mock.calls[0][0] as {embeds: Array<{toJSON: () => {description?: string}}>};
+    const description = response.embeds[0].toJSON().description;
+    expect(description).toContain('**Add to queue reponses show for requester only**: yes');
+    expect(description).toContain('**Reduce volume when people speak target**: 23');
+  });
+});

--- a/tests/command-event-gaps.test.ts
+++ b/tests/command-event-gaps.test.ts
@@ -1,0 +1,307 @@
+import 'reflect-metadata';
+import {Readable} from 'node:stream';
+import {Collection} from 'discord.js';
+import type {ChatInputCommandInteraction, VoiceState} from 'discord.js';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  containerGet: vi.fn(),
+  createAudioPlayer: vi.fn(),
+  createAudioResource: vi.fn(),
+  entersState: vi.fn(),
+  getGuildSettings: vi.fn(),
+  joinVoiceChannel: vi.fn(),
+  settingUpdate: vi.fn(),
+}));
+
+vi.mock('@discordjs/voice', () => ({
+  AudioPlayerStatus: {Idle: 'idle'},
+  VoiceConnectionDisconnectReason: {WebSocketClose: 'websocket-close'},
+  VoiceConnectionStatus: {
+    Connecting: 'connecting',
+    Disconnected: 'disconnected',
+    Ready: 'ready',
+    Signalling: 'signalling',
+  },
+  StreamType: {WebmOpus: 'webm-opus'},
+  createAudioPlayer: mocks.createAudioPlayer,
+  createAudioResource: mocks.createAudioResource,
+  entersState: mocks.entersState,
+  joinVoiceChannel: mocks.joinVoiceChannel,
+}));
+
+vi.mock('../src/inversify.config.js', () => ({
+  default: {get: mocks.containerGet},
+}));
+
+vi.mock('../src/services/file-cache.js', () => ({
+  default: class {},
+}));
+
+vi.mock('../src/utils/build-embed.js', () => ({
+  buildPlayingMessageEmbed: vi.fn(() => ({title: 'playing'})),
+}));
+
+vi.mock('../src/utils/db.js', () => ({
+  prisma: {setting: {update: mocks.settingUpdate}},
+}));
+
+vi.mock('../src/utils/get-guild-settings.js', () => ({
+  getGuildSettings: mocks.getGuildSettings,
+}));
+
+import Config from '../src/commands/config.js';
+import handleVoiceStateUpdate from '../src/events/voice-state-update.js';
+import Player, {MediaSource, QueuedSong, STATUS} from '../src/services/player.js';
+
+const GUILD_ID = 'guild-id';
+const VOICE_CHANNEL_ID = 'voice-channel-id';
+
+const makeAudioPlayer = () => ({
+  listeners: vi.fn(() => []),
+  on: vi.fn(),
+  pause: vi.fn(),
+  play: vi.fn(),
+  stop: vi.fn(),
+  unpause: vi.fn(),
+});
+
+const makeVoiceConnection = () => ({
+  destroy: vi.fn(),
+  joinConfig: {channelId: VOICE_CHANNEL_ID},
+  on: vi.fn(),
+  receiver: {speaking: {on: vi.fn()}},
+  rejoin: vi.fn(),
+  rejoinAttempts: 0,
+  state: {status: 'ready'},
+  subscribe: vi.fn(),
+});
+
+const makeSong = (): QueuedSong => ({
+  title: 'Queued song',
+  artist: 'Artist',
+  url: 'video-id',
+  length: 100,
+  offset: 0,
+  playlist: null,
+  isLive: false,
+  thumbnailUrl: null,
+  source: MediaSource.Youtube,
+  addedInChannelId: 'text-channel-id',
+  requestedBy: 'requester-id',
+});
+
+const getPrivateState = (player: Player) => player as unknown as {
+  disconnectTimer: NodeJS.Timeout | null;
+  finishQueue(): Promise<void>;
+};
+
+const makeConfigInteraction = (delay: number) => {
+  const reply = vi.fn().mockResolvedValue(undefined);
+  const interaction = {
+    guild: {id: GUILD_ID},
+    options: {
+      getInteger: vi.fn((name: string) => name === 'delay' ? delay : null),
+      getSubcommand: vi.fn(() => 'set-wait-after-queue-empties'),
+    },
+    reply,
+  } as unknown as ChatInputCommandInteraction;
+
+  return {interaction, reply};
+};
+
+const makeMembers = (...bots: boolean[]) => new Collection(
+  bots.map((bot, index) => [`member-${index}`, {user: {bot}}]),
+);
+
+const makeVoiceEventState = (
+  channelId: string | null,
+  members: Collection<string, {user: {bot: boolean}}>,
+): VoiceState => ({
+  channelId,
+  guild: {
+    id: GUILD_ID,
+    channels: {
+      cache: new Collection([[VOICE_CHANNEL_ID, {members}]]),
+    },
+  },
+}) as unknown as VoiceState;
+
+const installVoiceEventPlayer = () => {
+  const queue = [makeSong(), {...makeSong(), title: 'Upcoming song'}];
+  const voiceConnection = makeVoiceConnection();
+  const player = {
+    disconnect: vi.fn(),
+    getQueue: () => queue,
+    guildId: GUILD_ID,
+    voiceConnection,
+  };
+
+  mocks.containerGet.mockReturnValue({get: vi.fn(() => player)});
+
+  return {player, queue, voiceConnection};
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  mocks.createAudioPlayer.mockImplementation(makeAudioPlayer);
+  mocks.createAudioResource.mockImplementation((sourceStream: Readable) => ({
+    sourceStream,
+    volume: {setVolume: vi.fn()},
+  }));
+  mocks.entersState.mockResolvedValue(undefined);
+  mocks.getGuildSettings.mockResolvedValue({
+    autoAnnounceNextSong: false,
+    leaveIfNoListeners: true,
+    secondsToWaitAfterQueueEmpties: 0,
+  });
+  mocks.settingUpdate.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('/config set-wait-after-queue-empties', () => {
+  it.each([0, 37])('persists the nonnegative delay %i', async delay => {
+    const {interaction, reply} = makeConfigInteraction(delay);
+
+    await new Config().execute(interaction);
+
+    expect(mocks.getGuildSettings).toHaveBeenCalledWith(GUILD_ID);
+    expect(mocks.settingUpdate).toHaveBeenCalledWith({
+      where: {guildId: GUILD_ID},
+      data: {secondsToWaitAfterQueueEmpties: delay},
+    });
+    expect(reply).toHaveBeenCalledWith('👍 wait delay updated');
+  });
+});
+
+describe('queue exhaustion disconnect delay', () => {
+  it('does not schedule a disconnect when the configured delay is zero', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    const voiceConnection = makeVoiceConnection();
+    player.voiceConnection = voiceConnection as never;
+
+    await getPrivateState(player).finishQueue();
+
+    expect(player.status).toBe(STATUS.IDLE);
+    expect(getPrivateState(player).disconnectTimer).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(voiceConnection.destroy).not.toHaveBeenCalled();
+  });
+
+  it('disconnects after a positive delay when the player remains idle', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    const voiceConnection = makeVoiceConnection();
+    player.voiceConnection = voiceConnection as never;
+    mocks.getGuildSettings.mockResolvedValue({secondsToWaitAfterQueueEmpties: 5});
+
+    await getPrivateState(player).finishQueue();
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(voiceConnection.destroy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(voiceConnection.destroy).toHaveBeenCalledOnce();
+    expect(player.voiceConnection).toBeNull();
+  });
+
+  it('does not disconnect when the player is no longer idle at timeout', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    const voiceConnection = makeVoiceConnection();
+    player.voiceConnection = voiceConnection as never;
+    mocks.getGuildSettings.mockResolvedValue({secondsToWaitAfterQueueEmpties: 5});
+
+    await getPrivateState(player).finishQueue();
+    player.status = STATUS.PAUSED;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(voiceConnection.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(voiceConnection);
+  });
+
+  it('cancels a pending idle disconnect when playback starts again', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    const voiceConnection = makeVoiceConnection();
+    player.voiceConnection = voiceConnection as never;
+    player.add(makeSong());
+    Object.assign(player, {getStream: vi.fn().mockResolvedValue(Readable.from([]))});
+    mocks.getGuildSettings.mockResolvedValue({secondsToWaitAfterQueueEmpties: 5});
+
+    await getPrivateState(player).finishQueue();
+    expect(getPrivateState(player).disconnectTimer).not.toBeNull();
+
+    await player.play();
+
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(getPrivateState(player).disconnectTimer).toBeNull();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(voiceConnection.destroy).not.toHaveBeenCalled();
+  });
+});
+
+describe('voice-state listener departure behavior', () => {
+  it('disconnects from a bots-only configured channel when enabled without clearing the queue', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    const voiceConnection = makeVoiceConnection();
+    const current = makeSong();
+    const upcoming = {...makeSong(), title: 'Upcoming song'};
+    player.voiceConnection = voiceConnection as never;
+    player.add(current);
+    player.add(upcoming);
+    mocks.containerGet.mockReturnValue({get: vi.fn(() => player)});
+    const members = makeMembers(true, true);
+    const oldState = makeVoiceEventState(VOICE_CHANNEL_ID, members);
+    const newState = makeVoiceEventState(null, members);
+
+    await handleVoiceStateUpdate(oldState, newState);
+
+    expect(voiceConnection.destroy).toHaveBeenCalledOnce();
+    expect(player.voiceConnection).toBeNull();
+    expect(player.getCurrent()).toBe(current);
+    expect(player.getQueue()).toEqual([upcoming]);
+  });
+
+  it('stays connected when at least one human listener remains', async () => {
+    const {player} = installVoiceEventPlayer();
+    const members = makeMembers(true, false);
+
+    await handleVoiceStateUpdate(
+      makeVoiceEventState(VOICE_CHANNEL_ID, members),
+      makeVoiceEventState(null, members),
+    );
+
+    expect(player.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('stays connected to a bots-only channel when the setting is disabled', async () => {
+    const {player} = installVoiceEventPlayer();
+    const members = makeMembers(true, true);
+    mocks.getGuildSettings.mockResolvedValue({leaveIfNoListeners: false});
+
+    await handleVoiceStateUpdate(
+      makeVoiceEventState(VOICE_CHANNEL_ID, members),
+      makeVoiceEventState(null, members),
+    );
+
+    expect(player.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('ignores updates unrelated to the configured voice channel', async () => {
+    const {player} = installVoiceEventPlayer();
+    const members = makeMembers(true);
+
+    await handleVoiceStateUpdate(
+      makeVoiceEventState('other-channel', members),
+      makeVoiceEventState(null, members),
+    );
+
+    expect(mocks.getGuildSettings).not.toHaveBeenCalled();
+    expect(player.disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,33 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const loadConfig = async (cacheLimit: string) => {
+  vi.stubEnv('DISCORD_TOKEN', 'test-discord-token');
+  vi.stubEnv('YOUTUBE_API_KEY', 'test-youtube-key');
+  vi.stubEnv('DATA_DIR', '/tmp/muse-config-test');
+  vi.stubEnv('CACHE_LIMIT', cacheLimit);
+  const {default: Config} = await import('../src/services/config.js');
+  return Config;
+};
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('Config cache limit validation', () => {
+  it('rejects a negative cache limit with a clear error', async () => {
+    const Config = await loadConfig('-1B');
+
+    expect(() => new Config()).toThrow(/CACHE_LIMIT_IN_BYTES.*non-negative/i);
+  });
+
+  it('accepts a zero-byte cache limit', async () => {
+    const Config = await loadConfig('0B');
+
+    expect(new Config().CACHE_LIMIT_IN_BYTES).toBe(0);
+  });
+});

--- a/tests/file-cache.test.ts
+++ b/tests/file-cache.test.ts
@@ -65,13 +65,32 @@ const installDatabaseFake = () => {
   fileCache.delete.mockImplementation(async ({where}: {where: {hash: string}}) => rows.delete(where.hash));
   fileCache.findFirst.mockImplementation(async () => [...rows.values()]
     .sort((first, second) => first.accessedAt.getTime() - second.accessedAt.getTime())[0] ?? null);
-  fileCache.findMany.mockImplementation(async ({where, take}: {
-    where?: {hash: {gt: string}};
+  fileCache.findMany.mockImplementation(async ({where, orderBy, take}: {
+    where?: {
+      hash?: {gt: string};
+      createdAt?: {gt: Date};
+    };
+    orderBy?: {
+      hash?: 'asc' | 'desc';
+      createdAt?: 'asc' | 'desc';
+    };
     take: number;
-  }) => [...rows.values()]
-    .filter(row => !where || row.hash > where.hash.gt)
-    .sort((first, second) => first.hash.localeCompare(second.hash))
-    .slice(0, take));
+  }) => {
+    const matchingRows = [...rows.values()].filter(row => (
+      (!where?.hash || row.hash > where.hash.gt)
+      && (!where?.createdAt || row.createdAt > where.createdAt.gt)
+    ));
+
+    if (orderBy?.hash) {
+      const direction = orderBy.hash === 'asc' ? 1 : -1;
+      matchingRows.sort((first, second) => direction * first.hash.localeCompare(second.hash));
+    } else if (orderBy?.createdAt) {
+      const direction = orderBy.createdAt === 'asc' ? 1 : -1;
+      matchingRows.sort((first, second) => direction * (first.createdAt.getTime() - second.createdAt.getTime()));
+    }
+
+    return matchingRows.slice(0, take);
+  });
   fileCache.findUnique.mockImplementation(async ({where}: {where: {hash: string}}) => rows.get(where.hash) ?? null);
   fileCache.update.mockImplementation(async ({where, data}: {where: {hash: string}; data: {accessedAt: Date}}) => {
     const row = rows.get(where.hash);
@@ -441,9 +460,12 @@ describe('FileCacheProvider startup cleanup', () => {
   it('removes every missing database row when more than one page shares a creation time', async () => {
     const {provider} = await makeProvider();
     const sharedCreatedAt = new Date('2026-01-01T00:00:00Z');
+    const hashes = Array.from(
+      {length: 51},
+      (_, index) => `missing-${String(index).padStart(2, '0')}`,
+    ).reverse();
 
-    for (let index = 0; index < 51; index++) {
-      const hash = `missing-${String(index).padStart(2, '0')}`;
+    for (const hash of hashes) {
       dependencyMocks.rows.set(hash, {
         ...makeRow(hash, 1),
         createdAt: sharedCreatedAt,
@@ -454,6 +476,12 @@ describe('FileCacheProvider startup cleanup', () => {
 
     expect(dependencyMocks.rows.size).toBe(0);
     expect(dependencyMocks.fileCache.delete).toHaveBeenCalledTimes(51);
+    expect(dependencyMocks.fileCache.findMany).toHaveBeenCalledTimes(3);
+    for (const [arguments_] of dependencyMocks.fileCache.findMany.mock.calls) {
+      expect(arguments_).toEqual(expect.objectContaining({
+        orderBy: {hash: 'asc'},
+      }));
+    }
   });
 });
 

--- a/tests/file-cache.test.ts
+++ b/tests/file-cache.test.ts
@@ -66,11 +66,11 @@ const installDatabaseFake = () => {
   fileCache.findFirst.mockImplementation(async () => [...rows.values()]
     .sort((first, second) => first.accessedAt.getTime() - second.accessedAt.getTime())[0] ?? null);
   fileCache.findMany.mockImplementation(async ({where, take}: {
-    where?: {createdAt: {gt: Date}};
+    where?: {hash: {gt: string}};
     take: number;
   }) => [...rows.values()]
-    .filter(row => !where || row.createdAt > where.createdAt.gt)
-    .sort((first, second) => first.createdAt.getTime() - second.createdAt.getTime())
+    .filter(row => !where || row.hash > where.hash.gt)
+    .sort((first, second) => first.hash.localeCompare(second.hash))
     .slice(0, take));
   fileCache.findUnique.mockImplementation(async ({where}: {where: {hash: string}}) => rows.get(where.hash) ?? null);
   fileCache.update.mockImplementation(async ({where, data}: {where: {hash: string}; data: {accessedAt: Date}}) => {
@@ -436,6 +436,24 @@ describe('FileCacheProvider startup cleanup', () => {
     expect(await pathExists(orphanPath)).toBe(false);
     expect(await pathExists(preservedDirectory)).toBe(true);
     expect(await fs.readFile(preservedFile, 'utf8')).toBe('keep');
+  });
+
+  it('removes every missing database row when more than one page shares a creation time', async () => {
+    const {provider} = await makeProvider();
+    const sharedCreatedAt = new Date('2026-01-01T00:00:00Z');
+
+    for (let index = 0; index < 51; index++) {
+      const hash = `missing-${String(index).padStart(2, '0')}`;
+      dependencyMocks.rows.set(hash, {
+        ...makeRow(hash, 1),
+        createdAt: sharedCreatedAt,
+      });
+    }
+
+    await provider.cleanup();
+
+    expect(dependencyMocks.rows.size).toBe(0);
+    expect(dependencyMocks.fileCache.delete).toHaveBeenCalledTimes(51);
   });
 });
 

--- a/tests/file-cache.test.ts
+++ b/tests/file-cache.test.ts
@@ -316,6 +316,127 @@ describe('FileCacheProvider concurrent finalization', () => {
       process.off('unhandledRejection', captureUnhandled);
     }
   });
+
+  it('discards a nonzero write destroyed with an error before finish', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const failure = new Error('source stream failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const link = vi.spyOn(fs, 'link');
+    const stream = provider.createWriteStream('partial-hash');
+    const temporaryPath = String(stream.path);
+    const hasInternalErrorBoundary = stream.listenerCount('error') > 0;
+    let finished = false;
+    const uncaughtExceptions: Error[] = [];
+    const unhandledRejections: unknown[] = [];
+    const captureUncaught = (error: Error) => uncaughtExceptions.push(error);
+    const captureUnhandled = (reason: unknown) => unhandledRejections.push(reason);
+
+    // Keep the RED run deterministic instead of letting the missing production
+    // boundary terminate Vitest. GREEN exercises only the production listener.
+    if (!hasInternalErrorBoundary) {
+      stream.on('error', () => {});
+    }
+
+    stream.once('finish', () => {
+      finished = true;
+    });
+    process.on('uncaughtExceptionMonitor', captureUncaught);
+    process.on('unhandledRejection', captureUnhandled);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        stream.write('partial payload', error => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      expect((await fs.stat(temporaryPath)).size).toBeGreaterThan(0);
+
+      const closed = waitForClose(stream);
+      stream.destroy(failure);
+      await closed;
+
+      await vi.waitFor(async () => {
+        expect(await pathExists(temporaryPath)).toBe(false);
+      });
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(finished).toBe(false);
+      expect(hasInternalErrorBoundary).toBe(true);
+      expect(await pathExists(path.join(cacheDirectory, 'partial-hash'))).toBe(false);
+      expect(dependencyMocks.rows.has('partial-hash')).toBe(false);
+      expect(link).not.toHaveBeenCalled();
+      expect(dependencyMocks.fileCache.upsert).not.toHaveBeenCalled();
+      expect(dependencyMocks.fileCache.aggregate).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith('Failed to write cache temporary file:', failure);
+      expect(dependencyMocks.debug).toHaveBeenCalledWith('Failed to write cache temporary file: source stream failed');
+      expect(uncaughtExceptions).toEqual([]);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('uncaughtExceptionMonitor', captureUncaught);
+      process.off('unhandledRejection', captureUnhandled);
+    }
+  });
+
+  it('discards a nonzero write destroyed without an error before finish', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const link = vi.spyOn(fs, 'link');
+    const stream = provider.createWriteStream('aborted-hash');
+    const temporaryPath = String(stream.path);
+    let finished = false;
+    stream.once('finish', () => {
+      finished = true;
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      stream.write('partial payload', error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+    expect((await fs.stat(temporaryPath)).size).toBeGreaterThan(0);
+
+    const closed = waitForClose(stream);
+    stream.destroy();
+    await closed;
+
+    await vi.waitFor(async () => {
+      expect(await pathExists(temporaryPath)).toBe(false);
+    });
+
+    expect(finished).toBe(false);
+    expect(await pathExists(path.join(cacheDirectory, 'aborted-hash'))).toBe(false);
+    expect(dependencyMocks.rows.has('aborted-hash')).toBe(false);
+    expect(link).not.toHaveBeenCalled();
+    expect(dependencyMocks.fileCache.upsert).not.toHaveBeenCalled();
+    expect(dependencyMocks.fileCache.aggregate).not.toHaveBeenCalled();
+    expect(dependencyMocks.fileCache.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('FileCacheProvider startup cleanup', () => {
+  it('removes regular temporary-file orphans and leaves directories alone', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const temporaryDirectory = path.join(cacheDirectory, 'tmp');
+    const orphanPath = path.join(temporaryDirectory, 'abandoned.123e4567-e89b-12d3-a456-426614174000');
+    const preservedDirectory = path.join(temporaryDirectory, 'preserved-directory');
+    const preservedFile = path.join(preservedDirectory, 'nested-file');
+    await fs.writeFile(orphanPath, 'partial');
+    await fs.mkdir(preservedDirectory);
+    await fs.writeFile(preservedFile, 'keep');
+
+    await provider.cleanup();
+
+    expect(await pathExists(orphanPath)).toBe(false);
+    expect(await pathExists(preservedDirectory)).toBe(true);
+    expect(await fs.readFile(preservedFile, 'utf8')).toBe('keep');
+  });
 });
 
 describe('FileCacheProvider eviction', () => {

--- a/tests/file-cache.test.ts
+++ b/tests/file-cache.test.ts
@@ -1,0 +1,373 @@
+import {promises as fs} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import PQueue from 'p-queue';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const dependencyMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  fileCache: {
+    aggregate: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+  },
+  rows: new Map<string, {
+    hash: string;
+    bytes: number;
+    accessedAt: Date;
+    createdAt: Date;
+    updatedAt: Date;
+  }>(),
+}));
+
+vi.mock('../src/utils/db.js', () => ({
+  prisma: {fileCache: dependencyMocks.fileCache},
+}));
+
+vi.mock('../src/utils/debug.js', () => ({
+  default: dependencyMocks.debug,
+}));
+
+import FileCacheProvider from '../src/services/file-cache.js';
+
+const tempDirectories: string[] = [];
+
+const makeRow = (hash: string, bytes: number, accessedAt = new Date()) => ({
+  hash,
+  bytes,
+  accessedAt,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const installDatabaseFake = () => {
+  const {fileCache, rows} = dependencyMocks;
+
+  fileCache.aggregate.mockImplementation(async () => ({
+    _sum: {
+      bytes: [...rows.values()].reduce((total, row) => total + row.bytes, 0),
+    },
+  }));
+  fileCache.create.mockImplementation(async ({data}: {data: {hash: string; bytes: number; accessedAt: Date}}) => {
+    if (rows.has(data.hash)) {
+      throw new Error(`Unique constraint failed for ${data.hash}`);
+    }
+
+    const row = makeRow(data.hash, data.bytes, data.accessedAt);
+    rows.set(data.hash, row);
+    return row;
+  });
+  fileCache.delete.mockImplementation(async ({where}: {where: {hash: string}}) => rows.delete(where.hash));
+  fileCache.findFirst.mockImplementation(async () => [...rows.values()]
+    .sort((first, second) => first.accessedAt.getTime() - second.accessedAt.getTime())[0] ?? null);
+  fileCache.findMany.mockImplementation(async ({where, take}: {
+    where?: {createdAt: {gt: Date}};
+    take: number;
+  }) => [...rows.values()]
+    .filter(row => !where || row.createdAt > where.createdAt.gt)
+    .sort((first, second) => first.createdAt.getTime() - second.createdAt.getTime())
+    .slice(0, take));
+  fileCache.findUnique.mockImplementation(async ({where}: {where: {hash: string}}) => rows.get(where.hash) ?? null);
+  fileCache.update.mockImplementation(async ({where, data}: {where: {hash: string}; data: {accessedAt: Date}}) => {
+    const row = rows.get(where.hash);
+    if (!row) {
+      throw new Error(`Missing cache row ${where.hash}`);
+    }
+
+    const updated = {...row, ...data, updatedAt: new Date()};
+    rows.set(where.hash, updated);
+    return updated;
+  });
+  fileCache.upsert.mockImplementation(async ({where, create, update}: {
+    where: {hash: string};
+    create: {hash: string; bytes: number; accessedAt: Date};
+    update: {bytes: number; accessedAt: Date};
+  }) => {
+    const existing = rows.get(where.hash);
+    const row = existing
+      ? {...existing, ...update, updatedAt: new Date()}
+      : makeRow(create.hash, create.bytes, create.accessedAt);
+    rows.set(where.hash, row);
+    return row;
+  });
+};
+
+const makeProvider = async (cacheLimit = Number.MAX_SAFE_INTEGER) => {
+  const cacheDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'muse-file-cache-'));
+  tempDirectories.push(cacheDirectory);
+  await fs.mkdir(path.join(cacheDirectory, 'tmp'));
+
+  const provider = new FileCacheProvider({
+    CACHE_DIR: cacheDirectory,
+    CACHE_LIMIT_IN_BYTES: cacheLimit,
+  } as never);
+
+  return {cacheDirectory, provider};
+};
+
+const waitForClose = (stream: NodeJS.WritableStream) => new Promise<void>(resolve => {
+  stream.once('close', resolve);
+});
+
+const pathExists = async (filePath: string) => {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  dependencyMocks.rows.clear();
+  installDatabaseFake();
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirectories.splice(0).map(async directory => fs.rm(directory, {force: true, recursive: true})));
+});
+
+describe('FileCacheProvider concurrent finalization', () => {
+  it('uses unique temporary paths and converges same-hash writers without an unhandled rejection', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const unhandledRejections: unknown[] = [];
+    const captureUnhandled = (reason: unknown) => unhandledRejections.push(reason);
+    process.on('unhandledRejection', captureUnhandled);
+
+    try {
+      const first = provider.createWriteStream('same-hash');
+      const second = provider.createWriteStream('same-hash');
+      const firstTemporaryPath = String(first.path);
+      const secondTemporaryPath = String(second.path);
+      const firstClosed = waitForClose(first);
+      const secondClosed = waitForClose(second);
+
+      first.end('writer-one');
+      second.end('writer-two-is-longer');
+      await Promise.all([firstClosed, secondClosed]);
+
+      await vi.waitFor(async () => {
+        expect(dependencyMocks.rows.size).toBe(1);
+        expect(await fs.readdir(path.join(cacheDirectory, 'tmp'))).toEqual([]);
+      });
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      const finalContents = await fs.readFile(path.join(cacheDirectory, 'same-hash'), 'utf8');
+      const row = dependencyMocks.rows.get('same-hash');
+      expect(firstTemporaryPath).not.toBe(secondTemporaryPath);
+      expect(['writer-one', 'writer-two-is-longer']).toContain(finalContents);
+      expect(row?.bytes).toBe(Buffer.byteLength(finalContents));
+      expect(dependencyMocks.fileCache.upsert).toHaveBeenCalled();
+      expect(dependencyMocks.fileCache.create).not.toHaveBeenCalled();
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', captureUnhandled);
+    }
+  });
+
+  it('keeps every indexed file readable when cleanup is queued between final stat and upsert', async () => {
+    const {cacheDirectory, provider} = await makeProvider(4);
+    const existing = makeRow('same-hash', 4, new Date('2026-01-01T00:00:00Z'));
+    const survivor = makeRow('survivor', 4, new Date('2026-01-02T00:00:00Z'));
+    dependencyMocks.rows.set(existing.hash, existing);
+    dependencyMocks.rows.set(survivor.hash, survivor);
+    await fs.writeFile(path.join(cacheDirectory, existing.hash), 'old!');
+    await fs.writeFile(path.join(cacheDirectory, survivor.hash), 'keep');
+
+    let markUpsertStarted!: () => void;
+    let releaseUpsert!: () => void;
+    const upsertStarted = new Promise<void>(resolve => {
+      markUpsertStarted = resolve;
+    });
+    const upsertCanFinish = new Promise<void>(resolve => {
+      releaseUpsert = resolve;
+    });
+    const persistUpsert = dependencyMocks.fileCache.upsert.getMockImplementation();
+    dependencyMocks.fileCache.upsert.mockImplementation(async args => {
+      markUpsertStarted();
+      await upsertCanFinish;
+      return persistUpsert!(args);
+    });
+
+    const originalQueueAdd = PQueue.prototype.add;
+    const observedQueues = new Set<PQueue>();
+    const queueAdd = vi.spyOn(PQueue.prototype, 'add').mockImplementation(function (this: PQueue, ...args: any[]) {
+      observedQueues.add(this);
+      return Reflect.apply(originalQueueAdd, this, args);
+    });
+    const stream = provider.createWriteStream('same-hash');
+    const streamErrors: unknown[] = [];
+    stream.on('error', error => streamErrors.push(error));
+    const closed = waitForClose(stream);
+    stream.end('replacement-writer');
+    await closed;
+    await upsertStarted;
+
+    const queueAddsBeforeCleanup = queueAdd.mock.calls.length;
+    const cleanup = provider.cleanup();
+    await vi.waitFor(() => {
+      expect(queueAdd.mock.calls.length).toBeGreaterThan(queueAddsBeforeCleanup);
+    });
+    releaseUpsert();
+
+    await cleanup;
+    await vi.waitFor(async () => {
+      expect(await fs.readdir(path.join(cacheDirectory, 'tmp'))).toEqual([]);
+    });
+    await Promise.all([...observedQueues].map(async queue => queue.onIdle()));
+
+    expect(dependencyMocks.rows.size).toBe(1);
+    for (const row of dependencyMocks.rows.values()) {
+      const contents = await fs.readFile(path.join(cacheDirectory, row.hash));
+      expect(contents.byteLength).toBe(row.bytes);
+    }
+    expect(streamErrors).toEqual([]);
+  });
+
+  it('removes a zero-byte temporary file without publishing or indexing it', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const stream = provider.createWriteStream('empty-hash');
+    const closed = waitForClose(stream);
+
+    stream.end();
+    await closed;
+
+    await vi.waitFor(async () => {
+      expect(await fs.readdir(path.join(cacheDirectory, 'tmp'))).toEqual([]);
+    });
+    expect(await pathExists(path.join(cacheDirectory, 'empty-hash'))).toBe(false);
+    expect(dependencyMocks.rows.has('empty-hash')).toBe(false);
+    expect(dependencyMocks.fileCache.upsert).not.toHaveBeenCalled();
+  });
+
+  it('contains an atomic-finalization failure, removes its temporary file, and emits a stream error', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const failure = new Error('atomic finalization failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(fs, 'link').mockRejectedValueOnce(failure);
+    const stream = provider.createWriteStream('failed-hash');
+    const streamErrors: unknown[] = [];
+    const unhandledRejections: unknown[] = [];
+    const captureUnhandled = (reason: unknown) => unhandledRejections.push(reason);
+    stream.on('error', error => streamErrors.push(error));
+    process.on('unhandledRejection', captureUnhandled);
+
+    try {
+      const closed = waitForClose(stream);
+      stream.end('payload');
+      await closed;
+
+      await vi.waitFor(async () => {
+        expect(streamErrors).toEqual([failure]);
+        expect(await fs.readdir(path.join(cacheDirectory, 'tmp'))).toEqual([]);
+      });
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(await pathExists(path.join(cacheDirectory, 'failed-hash'))).toBe(false);
+      expect(dependencyMocks.rows.has('failed-hash')).toBe(false);
+      expect(consoleError).toHaveBeenCalledWith('Failed to finalize cache write:', failure);
+      expect(dependencyMocks.debug).toHaveBeenCalledWith('Failed to finalize cache write: atomic finalization failed');
+      expect(unhandledRejections).toEqual([]);
+
+      const recovery = provider.createWriteStream('recovery-hash');
+      const recoveryClosed = waitForClose(recovery);
+      recovery.end('recovered');
+      await recoveryClosed;
+      await vi.waitFor(async () => {
+        expect(await fs.readFile(path.join(cacheDirectory, 'recovery-hash'), 'utf8')).toBe('recovered');
+        expect(dependencyMocks.rows.has('recovery-hash')).toBe(true);
+      });
+    } finally {
+      process.off('unhandledRejection', captureUnhandled);
+    }
+  });
+
+  it('logs a finalization failure when no stream error listener is attached', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const failure = new Error('unobserved finalization failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(fs, 'link').mockRejectedValueOnce(failure);
+    const unhandledRejections: unknown[] = [];
+    const captureUnhandled = (reason: unknown) => unhandledRejections.push(reason);
+    process.on('unhandledRejection', captureUnhandled);
+
+    try {
+      const stream = provider.createWriteStream('unobserved-failure');
+      const closed = waitForClose(stream);
+      stream.end('payload');
+      await closed;
+
+      await vi.waitFor(async () => {
+        expect(dependencyMocks.debug).toHaveBeenCalledWith('Failed to finalize cache write: unobserved finalization failed');
+        expect(await fs.readdir(path.join(cacheDirectory, 'tmp'))).toEqual([]);
+      });
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(consoleError).toHaveBeenCalledWith('Failed to finalize cache write:', failure);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', captureUnhandled);
+    }
+  });
+});
+
+describe('FileCacheProvider eviction', () => {
+  it('keeps concurrent eviction passes serialized', async () => {
+    const {provider} = await makeProvider();
+    let activePasses = 0;
+    let aggregateCalls = 0;
+    let maximumActivePasses = 0;
+    dependencyMocks.fileCache.aggregate.mockImplementation(async () => {
+      activePasses++;
+      aggregateCalls++;
+      maximumActivePasses = Math.max(maximumActivePasses, activePasses);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      activePasses--;
+      return {_sum: {bytes: 0}};
+    });
+
+    await Promise.all([provider.cleanup(), provider.cleanup()]);
+    await vi.waitFor(() => {
+      expect(activePasses).toBe(0);
+    });
+
+    expect(aggregateCalls).toBe(2);
+    expect(maximumActivePasses).toBe(1);
+  });
+
+  it('preserves least-recently-accessed eviction order', async () => {
+    const {cacheDirectory, provider} = await makeProvider(4);
+    const oldest = makeRow('oldest', 4, new Date('2026-01-01T00:00:00Z'));
+    const newest = makeRow('newest', 4, new Date('2026-01-02T00:00:00Z'));
+    dependencyMocks.rows.set(oldest.hash, oldest);
+    dependencyMocks.rows.set(newest.hash, newest);
+    await fs.writeFile(path.join(cacheDirectory, oldest.hash), 'old!');
+    await fs.writeFile(path.join(cacheDirectory, newest.hash), 'new!');
+
+    await provider.cleanup();
+
+    expect(dependencyMocks.fileCache.delete).toHaveBeenCalledWith({where: {hash: 'oldest'}});
+    expect(dependencyMocks.rows.has('oldest')).toBe(false);
+    expect(await pathExists(path.join(cacheDirectory, 'oldest'))).toBe(false);
+    expect(dependencyMocks.rows.has('newest')).toBe(true);
+    expect(await fs.readFile(path.join(cacheDirectory, 'newest'), 'utf8')).toBe('new!');
+  });
+
+  it('rejects cleanup after one no-progress check when usage is above limit but no row is evictable', async () => {
+    const {provider} = await makeProvider(0);
+    dependencyMocks.fileCache.aggregate
+      .mockResolvedValueOnce({_sum: {bytes: 1}})
+      .mockResolvedValue({_sum: {bytes: 0}});
+    dependencyMocks.fileCache.findFirst.mockResolvedValue(null);
+
+    await expect(provider.cleanup()).rejects.toThrow(/cache.*limit.*no.*evict/i);
+    expect(dependencyMocks.fileCache.findFirst).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ops-integrations.test.ts
+++ b/tests/ops-integrations.test.ts
@@ -1,0 +1,734 @@
+import 'reflect-metadata';
+import {promises as fs} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {Readable} from 'node:stream';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const dependencyMocks = vi.hoisted(() => ({
+  createAudioPlayer: vi.fn(),
+  createAudioResource: vi.fn(),
+  debug: vi.fn(),
+  entersState: vi.fn(),
+  execa: vi.fn(),
+  ffmpeg: vi.fn(),
+  getGuildSettings: vi.fn(),
+  joinVoiceChannel: vi.fn(),
+  sleep: vi.fn(),
+  spotifyClientCredentialsGrant: vi.fn(),
+  spotifyConstructorOptions: [] as unknown[],
+  spotifySetAccessToken: vi.fn(),
+}));
+
+vi.mock('@discordjs/voice', () => ({
+  AudioPlayerStatus: {Idle: 'idle'},
+  VoiceConnectionDisconnectReason: {WebSocketClose: 'websocket-close'},
+  VoiceConnectionStatus: {
+    Connecting: 'connecting',
+    Disconnected: 'disconnected',
+    Ready: 'ready',
+    Signalling: 'signalling',
+  },
+  StreamType: {WebmOpus: 'webm-opus'},
+  createAudioPlayer: dependencyMocks.createAudioPlayer,
+  createAudioResource: dependencyMocks.createAudioResource,
+  entersState: dependencyMocks.entersState,
+  joinVoiceChannel: dependencyMocks.joinVoiceChannel,
+}));
+
+vi.mock('timers/promises', () => ({
+  setTimeout: dependencyMocks.sleep,
+}));
+
+vi.mock('execa', () => ({
+  execa: dependencyMocks.execa,
+}));
+
+vi.mock('fluent-ffmpeg', () => ({
+  default: dependencyMocks.ffmpeg,
+}));
+
+vi.mock('spotify-web-api-node', () => ({
+  default: class {
+    clientCredentialsGrant = dependencyMocks.spotifyClientCredentialsGrant;
+    setAccessToken = dependencyMocks.spotifySetAccessToken;
+
+    constructor(options: unknown) {
+      dependencyMocks.spotifyConstructorOptions.push(options);
+    }
+  },
+}));
+
+vi.mock('../src/services/file-cache.js', () => ({
+  default: class {},
+}));
+
+vi.mock('../src/utils/build-embed.js', () => ({
+  buildPlayingMessageEmbed: vi.fn(() => ({title: 'playing'})),
+}));
+
+vi.mock('../src/utils/get-guild-settings.js', () => ({
+  getGuildSettings: dependencyMocks.getGuildSettings,
+}));
+
+vi.mock('../src/utils/debug.js', () => ({
+  default: dependencyMocks.debug,
+}));
+
+import Player, {MediaSource, QueuedSong} from '../src/services/player.js';
+import ThirdParty from '../src/services/third-party.js';
+import prepareYtDlp from '../src/utils/prepare-yt-dlp.js';
+import {getExecutable, getYouTubeMediaSource, getYtDlpVersion, updateYtDlp} from '../src/utils/yt-dlp.js';
+
+const GUILD_ID = 'guild-id';
+const ORIGINAL_ENV = {
+  DISCORD_TOKEN: process.env.DISCORD_TOKEN,
+  MUSE_BUNDLED_YT_DLP_PATH: process.env.MUSE_BUNDLED_YT_DLP_PATH,
+  PATH: process.env.PATH,
+  SPOTIFY_CLIENT_ID: process.env.SPOTIFY_CLIENT_ID,
+  SPOTIFY_CLIENT_SECRET: process.env.SPOTIFY_CLIENT_SECRET,
+  YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
+  YT_DLP_COOKIES_PATH: process.env.YT_DLP_COOKIES_PATH,
+  YT_DLP_PATH: process.env.YT_DLP_PATH,
+};
+const VALID_MEDIA_RESPONSE = JSON.stringify({
+  requested_downloads: [{
+    url: 'https://media.example/requested.webm',
+    http_headers: {
+      Authorization: 'Bearer media-token',
+      'User-Agent': 'Muse ops test',
+      Empty: '',
+      Missing: null,
+    },
+  }],
+  http_headers: {'X-Fallback': 'not-used'},
+  is_live: true,
+});
+
+const makeDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return {promise, reject, resolve};
+};
+
+const flushAsyncWork = async () => {
+  for (let index = 0; index < 12; index++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+};
+
+const makeFfmpegCommand = () => {
+  const command = {
+    audioCodec: vi.fn(() => command),
+    inputOptions: vi.fn(() => command),
+    kill: vi.fn(),
+    noVideo: vi.fn(() => command),
+    on: vi.fn(() => command),
+    outputFormat: vi.fn(() => command),
+    pipe: vi.fn((destination: {end(): void}) => {
+      destination.end();
+      return destination;
+    }),
+  };
+
+  return command;
+};
+
+const makeExecutableLayout = async (includePython = true) => {
+  const root = await fs.mkdtemp(path.join(tmpdir(), 'muse-ops-yt-dlp-'));
+  const bin = path.join(root, 'bin');
+  const executable = path.join(bin, 'yt-dlp');
+  const python = path.join(bin, 'python');
+  await fs.mkdir(bin);
+  await fs.writeFile(executable, '#!/bin/sh\n', {mode: 0o755});
+  if (includePython) {
+    await fs.writeFile(python, '#!/bin/sh\n', {mode: 0o755});
+  }
+
+  return {executable, python, root};
+};
+
+const loadSpotifyBindingHarness = async (clientId: string, clientSecret: string) => {
+  vi.resetModules();
+  process.env.DISCORD_TOKEN = 'synthetic-discord-token';
+  process.env.YOUTUBE_API_KEY = 'synthetic-youtube-key';
+  process.env.SPOTIFY_CLIENT_ID = clientId;
+  process.env.SPOTIFY_CLIENT_SECRET = clientSecret;
+  vi.doMock('discord.js', async () => {
+    const actual = await vi.importActual<typeof import('discord.js')>('discord.js');
+
+    return {
+      ...actual,
+      Client: class {},
+    };
+  });
+
+  const [{default: container}, {TYPES}, {default: Play}] = await Promise.all([
+    import('../src/inversify.config.js'),
+    import('../src/types.js'),
+    import('../src/commands/play.js'),
+  ]);
+
+  return {container, Play, TYPES};
+};
+
+const makeVoiceConnection = (overrides: Record<string, unknown> = {}) => {
+  const handlers = new Map<string, (...args: unknown[]) => void>();
+  const connection = {
+    destroy: vi.fn(),
+    joinConfig: {channelId: 'voice-channel-id'},
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers.set(event, handler);
+      return connection;
+    }),
+    receiver: {speaking: {on: vi.fn()}},
+    rejoin: vi.fn(() => true),
+    rejoinAttempts: 0,
+    state: {status: 'ready'},
+    subscribe: vi.fn(),
+    ...overrides,
+  };
+
+  return {connection, handlers};
+};
+
+const getPrivatePlayer = (player: Player) => player as unknown as {
+  onVoiceConnectionDisconnect(): Promise<void>;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dependencyMocks.spotifyConstructorOptions.length = 0;
+  delete process.env.YT_DLP_COOKIES_PATH;
+  delete process.env.YT_DLP_PATH;
+  delete process.env.MUSE_BUNDLED_YT_DLP_PATH;
+  dependencyMocks.execa.mockResolvedValue({stdout: VALID_MEDIA_RESPONSE});
+  dependencyMocks.ffmpeg.mockImplementation(makeFfmpegCommand);
+  dependencyMocks.getGuildSettings.mockResolvedValue({
+    defaultVolume: 100,
+    turnDownVolumeWhenPeopleSpeak: false,
+  });
+  dependencyMocks.entersState.mockResolvedValue(undefined);
+  dependencyMocks.sleep.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+});
+
+describe('OPS-10 yt-dlp selection and update lifecycle', () => {
+  it('prefers YT_DLP_PATH and reports the trimmed installed version when auto-update is disabled', async () => {
+    process.env.YT_DLP_PATH = '/configured/yt-dlp';
+    process.env.MUSE_BUNDLED_YT_DLP_PATH = '/bundled/yt-dlp';
+    process.env.PATH = '/path/that/would/otherwise/be/searched';
+    dependencyMocks.execa.mockResolvedValue({stdout: ' 2026.07.12 \n'});
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    expect(getExecutable()).toBe('/configured/yt-dlp');
+    await expect(getYtDlpVersion()).resolves.toBe('2026.07.12');
+    await prepareYtDlp({YT_DLP_AUTO_UPDATE: false} as never);
+
+    expect(dependencyMocks.execa).toHaveBeenCalledWith('/configured/yt-dlp', ['--version'], {
+      timeout: 15_000,
+    });
+    expect(log).toHaveBeenCalledWith('YT_DLP_VERSION=2026.07.12 (/configured/yt-dlp)');
+  });
+
+  it('falls back from a blank configured path to the bundled executable and then the PATH command', () => {
+    process.env.YT_DLP_PATH = '   ';
+    process.env.MUSE_BUNDLED_YT_DLP_PATH = ' /bundled/yt-dlp ';
+    expect(getExecutable()).toBe('/bundled/yt-dlp');
+
+    delete process.env.MUSE_BUNDLED_YT_DLP_PATH;
+    expect(getExecutable()).toBe('yt-dlp');
+  });
+
+  it('prefers pip through the executable sibling virtualenv and re-probes the updated version', async () => {
+    const layout = await makeExecutableLayout();
+    const pythonExecutable = await fs.realpath(layout.python);
+    process.env.YT_DLP_PATH = layout.executable;
+    const versions = ['2026.01.01', '2026.07.12'];
+    dependencyMocks.execa.mockImplementation(async (executable: string, args: string[]) => {
+      if (args[0] === '--version') {
+        return {stdout: versions.shift()!};
+      }
+
+      if (executable === pythonExecutable) {
+        return {stdout: ''};
+      }
+
+      throw new Error(`Unexpected command: ${executable} ${args.join(' ')}`);
+    });
+
+    try {
+      await expect(updateYtDlp()).resolves.toEqual({
+        beforeVersion: '2026.01.01',
+        afterVersion: '2026.07.12',
+        updated: true,
+        skipped: false,
+        updateSucceeded: true,
+        error: undefined,
+      });
+      expect(dependencyMocks.execa).toHaveBeenNthCalledWith(2, pythonExecutable, [
+        '-m',
+        'pip',
+        'install',
+        '--disable-pip-version-check',
+        '--no-input',
+        '--upgrade',
+        'yt-dlp[default]',
+      ], {
+        env: {
+          PIP_DISABLE_PIP_VERSION_CHECK: '1',
+          PIP_NO_INPUT: '1',
+        },
+        timeout: 120_000,
+      });
+      expect(dependencyMocks.execa.mock.calls.some(([, args]) => (args as string[])[0] === '-U')).toBe(false);
+      expect(dependencyMocks.execa).toHaveBeenLastCalledWith(layout.executable, ['--version'], {
+        timeout: 15_000,
+      });
+    } finally {
+      await fs.rm(layout.root, {recursive: true, force: true});
+    }
+  });
+
+  it('falls back to self-update when sibling-venv pip fails and still re-probes', async () => {
+    const layout = await makeExecutableLayout();
+    const pythonExecutable = await fs.realpath(layout.python);
+    process.env.YT_DLP_PATH = layout.executable;
+    const versions = ['2026.01.01', '2026.07.12'];
+    dependencyMocks.execa.mockImplementation(async (executable: string, args: string[]) => {
+      if (args[0] === '--version') {
+        return {stdout: versions.shift()!};
+      }
+
+      if (executable === pythonExecutable) {
+        throw {stderr: 'pip update failed'};
+      }
+
+      if (executable === layout.executable && args[0] === '-U') {
+        return {stdout: ''};
+      }
+
+      throw new Error(`Unexpected command: ${executable} ${args.join(' ')}`);
+    });
+
+    try {
+      await expect(updateYtDlp()).resolves.toMatchObject({
+        beforeVersion: '2026.01.01',
+        afterVersion: '2026.07.12',
+        updated: true,
+        updateSucceeded: true,
+      });
+      expect(dependencyMocks.execa).toHaveBeenCalledWith(layout.executable, ['-U'], {
+        timeout: 120_000,
+      });
+      expect(dependencyMocks.execa).toHaveBeenLastCalledWith(layout.executable, ['--version'], {
+        timeout: 15_000,
+      });
+    } finally {
+      await fs.rm(layout.root, {recursive: true, force: true});
+    }
+  });
+
+  it('keeps an installed version nonfatal after both update mechanisms fail', async () => {
+    const layout = await makeExecutableLayout();
+    const pythonExecutable = await fs.realpath(layout.python);
+    process.env.YT_DLP_PATH = layout.executable;
+    dependencyMocks.execa.mockImplementation(async (executable: string, args: string[]) => {
+      if (args[0] === '--version') {
+        return {stdout: '2026.01.01'};
+      }
+
+      if (executable === pythonExecutable) {
+        throw {stderr: 'pip update failed'};
+      }
+
+      if (args[0] === '-U') {
+        throw {stderr: 'self update failed'};
+      }
+
+      throw new Error(`Unexpected command: ${executable} ${args.join(' ')}`);
+    });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      await expect(prepareYtDlp({YT_DLP_AUTO_UPDATE: true} as never)).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith('yt-dlp update warning: pip update failed; self update failed');
+      expect(log).toHaveBeenCalledWith(
+        'YT_DLP_VERSION=2026.01.01 (update failed; continuing with installed version)',
+      );
+      expect(dependencyMocks.execa.mock.calls.filter(([, args]) => (args as string[])[0] === '--version')).toHaveLength(2);
+    } finally {
+      await fs.rm(layout.root, {recursive: true, force: true});
+    }
+  });
+});
+
+describe('OPS-11 yt-dlp extraction and ffmpeg handoff', () => {
+  it('uses the bounded single-video Node-runtime extraction contract and normalizes the selected download', async () => {
+    process.env.YT_DLP_PATH = '/fake/yt-dlp';
+
+    await expect(getYouTubeMediaSource('abcdefghijk')).resolves.toEqual({
+      url: 'https://media.example/requested.webm',
+      headers: {
+        Authorization: 'Bearer media-token',
+        'User-Agent': 'Muse ops test',
+      },
+      isLive: true,
+    });
+    expect(dependencyMocks.execa).toHaveBeenCalledWith('/fake/yt-dlp', [
+      '--dump-single-json',
+      '--no-playlist',
+      '--skip-download',
+      '--no-warnings',
+      '--no-cache-dir',
+      '--js-runtimes',
+      'node',
+      '-f',
+      'bestaudio/best',
+      '-S',
+      'proto:https',
+      'https://www.youtube.com/watch?v=abcdefghijk',
+    ], {
+      timeout: 45_000,
+    });
+  });
+
+  it('hands reconnect and CRLF-normalized headers to ffmpeg', async () => {
+    process.env.YT_DLP_PATH = '/fake/yt-dlp';
+    const fileCache = {
+      getPathFor: vi.fn().mockResolvedValue(null),
+    };
+    const player = new Player(fileCache as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Long uncached track',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 3_600,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    const stream = await (player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song);
+    const command = dependencyMocks.ffmpeg.mock.results[0].value as ReturnType<typeof makeFfmpegCommand>;
+
+    expect(dependencyMocks.ffmpeg).toHaveBeenCalledWith('https://media.example/requested.webm');
+    expect(command.inputOptions).toHaveBeenCalledWith([
+      '-reconnect',
+      '1',
+      '-reconnect_streamed',
+      '1',
+      '-reconnect_delay_max',
+      '5',
+      '-headers',
+      'Authorization: Bearer media-token\r\nUser-Agent: Muse ops test\r\n',
+    ]);
+    expect(command.noVideo).toHaveBeenCalledOnce();
+    expect(command.audioCodec).toHaveBeenCalledWith('libopus');
+    expect(command.outputFormat).toHaveBeenCalledWith('webm');
+
+    stream.destroy();
+    await flushAsyncWork();
+  });
+});
+
+describe('OPS-12 optional Spotify bindings', () => {
+  it('binds both Spotify services and advertises Spotify only when both credentials are nonblank', async () => {
+    const {container, Play, TYPES} = await loadSpotifyBindingHarness(' client-id ', ' client-secret ');
+    const command = new Play({spotify: {}} as never, {} as never, {} as never);
+    const queryOption = command.slashCommand.toJSON().options?.find(option => option.name === 'query');
+
+    expect(container.isBound(TYPES.Services.SpotifyAPI)).toBe(true);
+    expect(container.isBound(TYPES.ThirdParty)).toBe(true);
+    expect(container.isBound(TYPES.Services.YoutubeAPI)).toBe(true);
+    expect(container.isBound(TYPES.Services.GetSongs)).toBe(true);
+    expect(queryOption?.description).toBe('YouTube URL, Spotify URL, or search query');
+  });
+
+  it.each([
+    ['', 'client-secret', 'missing ID'],
+    ['client-id', '', 'missing secret'],
+    ['   ', 'client-secret', 'blank ID'],
+    ['client-id', ' \t ', 'blank secret'],
+  ])('keeps core YouTube services and description when credentials have %s / %s (%s)', async (
+    clientId,
+    clientSecret,
+  ) => {
+    const {container, Play, TYPES} = await loadSpotifyBindingHarness(clientId, clientSecret);
+    const command = new Play(undefined as never, {} as never, {} as never);
+    const queryOption = command.slashCommand.toJSON().options?.find(option => option.name === 'query');
+
+    expect(container.isBound(TYPES.Services.SpotifyAPI)).toBe(false);
+    expect(container.isBound(TYPES.ThirdParty)).toBe(false);
+    expect(container.isBound(TYPES.Services.YoutubeAPI)).toBe(true);
+    expect(container.isBound(TYPES.Services.GetSongs)).toBe(true);
+    expect(queryOption?.description).toBe('YouTube URL or search query');
+  });
+});
+
+describe('OPS-12 Spotify token lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('installs the token, refreshes at half-life, and cleans up the pending timer', async () => {
+    dependencyMocks.spotifyClientCredentialsGrant
+      .mockResolvedValueOnce({body: {access_token: 'token-one', expires_in: 120}})
+      .mockResolvedValueOnce({body: {access_token: 'token-two', expires_in: 240}});
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    const service = new ThirdParty({
+      SPOTIFY_CLIENT_ID: 'client-id',
+      SPOTIFY_CLIENT_SECRET: 'client-secret',
+    } as never);
+    await flushAsyncWork();
+
+    expect(dependencyMocks.spotifyConstructorOptions).toEqual([{
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+    }]);
+    expect(dependencyMocks.spotifySetAccessToken).toHaveBeenNthCalledWith(1, 'token-one');
+    expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 60_000);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flushAsyncWork();
+
+    expect(dependencyMocks.spotifyClientCredentialsGrant).toHaveBeenCalledTimes(2);
+    expect(dependencyMocks.spotifySetAccessToken).toHaveBeenNthCalledWith(2, 'token-two');
+    expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 120_000);
+    expect(vi.getTimerCount()).toBe(1);
+
+    service.cleanup();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('bounds credential-grant retry to five retries before a successful sixth attempt', async () => {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      dependencyMocks.spotifyClientCredentialsGrant.mockRejectedValueOnce(new Error(`attempt ${attempt + 1}`));
+    }
+
+    dependencyMocks.spotifyClientCredentialsGrant.mockResolvedValueOnce({
+      body: {access_token: 'eventual-token', expires_in: 120},
+    });
+    const service = new ThirdParty({
+      SPOTIFY_CLIENT_ID: 'client-id',
+      SPOTIFY_CLIENT_SECRET: 'client-secret',
+    } as never);
+    await flushAsyncWork();
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    await flushAsyncWork();
+
+    expect(dependencyMocks.spotifyClientCredentialsGrant).toHaveBeenCalledTimes(6);
+    expect(dependencyMocks.spotifySetAccessToken).toHaveBeenCalledOnce();
+    expect(dependencyMocks.spotifySetAccessToken).toHaveBeenCalledWith('eventual-token');
+    expect(vi.getTimerCount()).toBe(1);
+
+    service.cleanup();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('logs exhausted refresh failure and reschedules one attempt after 60 seconds', async () => {
+    dependencyMocks.spotifyClientCredentialsGrant.mockRejectedValue(new Error('Spotify auth unavailable'));
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    const service = new ThirdParty({
+      SPOTIFY_CLIENT_ID: 'client-id',
+      SPOTIFY_CLIENT_SECRET: 'client-secret',
+    } as never);
+    await flushAsyncWork();
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    await flushAsyncWork();
+
+    expect(dependencyMocks.spotifyClientCredentialsGrant).toHaveBeenCalledTimes(6);
+    expect(dependencyMocks.spotifySetAccessToken).not.toHaveBeenCalled();
+    expect(dependencyMocks.debug).toHaveBeenCalledWith(
+      'Spotify token refresh failed: %O',
+      expect.objectContaining({message: 'Spotify auth unavailable'}),
+    );
+    expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 60_000);
+    expect(vi.getTimerCount()).toBe(1);
+
+    service.cleanup();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('OPS-13 transient voice recovery', () => {
+  it.each(['connecting', 'signalling'])('keeps a 4014 connection when it recovers through %s', async recoveredStatus => {
+    const never = new Promise<void>(() => undefined);
+    dependencyMocks.entersState.mockImplementation(async (_connection, status: string) => (
+      status === recoveredStatus ? undefined : never
+    ));
+    const {connection} = makeVoiceConnection({
+      state: {
+        status: 'disconnected',
+        reason: 'websocket-close',
+        closeCode: 4014,
+      },
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = connection as never;
+
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect();
+
+    expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'connecting', 5_000);
+    expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'signalling', 5_000);
+    expect(connection.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(connection);
+  });
+
+  it('destroys a 4014 connection when both five-second recovery waits time out', async () => {
+    dependencyMocks.entersState.mockRejectedValue(new Error('recovery timed out'));
+    const {connection} = makeVoiceConnection({
+      state: {
+        status: 'disconnected',
+        reason: 'websocket-close',
+        closeCode: 4014,
+      },
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = connection as never;
+
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect();
+
+    expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'connecting', 5_000);
+    expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'signalling', 5_000);
+    expect(connection.destroy).toHaveBeenCalledOnce();
+    expect(player.voiceConnection).toBeNull();
+  });
+
+  it('backs off in five-second increments and rejoins below five attempts', async () => {
+    const backoff = makeDeferred<void>();
+    dependencyMocks.sleep.mockReturnValue(backoff.promise);
+    const {connection} = makeVoiceConnection({
+      rejoinAttempts: 2,
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = connection as never;
+
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect();
+    expect(dependencyMocks.sleep).toHaveBeenCalledWith(15_000);
+    backoff.resolve(undefined);
+    await recovery;
+
+    expect(connection.rejoin).toHaveBeenCalledOnce();
+    expect(connection.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(connection);
+  });
+
+  it('does not destroy a connection that becomes Ready during disconnect backoff', async () => {
+    const backoff = makeDeferred<void>();
+    dependencyMocks.sleep.mockReturnValue(backoff.promise);
+    const {connection} = makeVoiceConnection({
+      rejoinAttempts: 1,
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = connection as never;
+
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect();
+    expect(dependencyMocks.sleep).toHaveBeenCalledWith(10_000);
+
+    connection.state.status = 'ready';
+    backoff.resolve(undefined);
+    await recovery;
+
+    expect(connection.rejoin).not.toHaveBeenCalled();
+    expect(connection.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(connection);
+  });
+
+  it('destroys a still-disconnected connection when rejoin fails below five attempts', async () => {
+    const {connection} = makeVoiceConnection({
+      rejoin: vi.fn(() => false),
+      rejoinAttempts: 0,
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = connection as never;
+
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect();
+
+    expect(dependencyMocks.sleep).toHaveBeenCalledWith(5_000);
+    expect(connection.rejoin).toHaveBeenCalledOnce();
+    expect(connection.destroy).toHaveBeenCalledOnce();
+    expect(player.voiceConnection).toBeNull();
+  });
+
+  it('destroys immediately when rejoin attempts are exhausted', async () => {
+    const {connection} = makeVoiceConnection({
+      rejoinAttempts: 5,
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = connection as never;
+
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect();
+
+    expect(dependencyMocks.sleep).not.toHaveBeenCalled();
+    expect(connection.rejoin).not.toHaveBeenCalled();
+    expect(connection.destroy).toHaveBeenCalledOnce();
+    expect(player.voiceConnection).toBeNull();
+  });
+
+  it('uses a 60-second initial Ready wait and preserves status, attempts, and recent-state diagnostics', async () => {
+    const ready = makeDeferred<void>();
+    dependencyMocks.entersState.mockReturnValue(ready.promise);
+    const {connection, handlers} = makeVoiceConnection({
+      rejoinAttempts: 3,
+      state: {status: 'connecting'},
+    });
+    dependencyMocks.joinVoiceChannel.mockReturnValue(connection);
+    const player = new Player({} as never, GUILD_ID);
+    const channel = {
+      id: 'voice-channel-id',
+      guild: {
+        id: GUILD_ID,
+        voiceAdapterCreator: {},
+      },
+    };
+
+    const connecting = player.connect(channel as never);
+    await flushAsyncWork();
+    expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'ready', 60_000);
+
+    handlers.get('stateChange')!({status: 'connecting'}, {status: 'signalling'});
+    handlers.get('stateChange')!({status: 'signalling'}, {status: 'disconnected'});
+    connection.state.status = 'disconnected';
+    ready.reject(new Error('initial Ready timeout'));
+
+    await expect(connecting).rejects.toThrow(
+      'Failed to connect to the voice channel (last state: disconnected, rejoin attempts: 3, recent states: connecting -> signalling -> disconnected).',
+    );
+    expect(connection.destroy).toHaveBeenCalledOnce();
+    expect(player.voiceConnection).toBeNull();
+  });
+});

--- a/tests/ops-integrations.test.ts
+++ b/tests/ops-integrations.test.ts
@@ -26,6 +26,7 @@ vi.mock('@discordjs/voice', () => ({
   VoiceConnectionStatus: {
     Connecting: 'connecting',
     Disconnected: 'disconnected',
+    Destroyed: 'destroyed',
     Ready: 'ready',
     Signalling: 'signalling',
   },
@@ -199,7 +200,7 @@ const makeVoiceConnection = (overrides: Record<string, unknown> = {}) => {
 };
 
 const getPrivatePlayer = (player: Player) => player as unknown as {
-  onVoiceConnectionDisconnect(): Promise<void>;
+  onVoiceConnectionDisconnect(connection: object): Promise<void>;
 };
 
 beforeEach(() => {
@@ -596,7 +597,7 @@ describe('OPS-13 transient voice recovery', () => {
     const player = new Player({} as never, GUILD_ID);
     player.voiceConnection = connection as never;
 
-    await getPrivatePlayer(player).onVoiceConnectionDisconnect();
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect(connection);
 
     expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'connecting', 5_000);
     expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'signalling', 5_000);
@@ -616,12 +617,40 @@ describe('OPS-13 transient voice recovery', () => {
     const player = new Player({} as never, GUILD_ID);
     player.voiceConnection = connection as never;
 
-    await getPrivatePlayer(player).onVoiceConnectionDisconnect();
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect(connection);
 
     expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'connecting', 5_000);
     expect(dependencyMocks.entersState).toHaveBeenCalledWith(connection, 'signalling', 5_000);
     expect(connection.destroy).toHaveBeenCalledOnce();
     expect(player.voiceConnection).toBeNull();
+  });
+
+  it('does not disconnect a replacement when an old 4014 recovery wait later times out', async () => {
+    const oldRecovery = makeDeferred<void>();
+    dependencyMocks.entersState.mockReturnValue(oldRecovery.promise);
+    const {connection: oldConnection} = makeVoiceConnection({
+      state: {
+        status: 'disconnected',
+        reason: 'websocket-close',
+        closeCode: 4014,
+      },
+    });
+    const {connection: replacement} = makeVoiceConnection({
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = oldConnection as never;
+
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect(oldConnection);
+    await flushAsyncWork();
+    player.voiceConnection = replacement as never;
+    oldRecovery.reject(new Error('old 4014 recovery timed out'));
+    await recovery;
+
+    expect(oldConnection.destroy).not.toHaveBeenCalled();
+    expect(replacement.rejoin).not.toHaveBeenCalled();
+    expect(replacement.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(replacement);
   });
 
   it('backs off in five-second increments and rejoins below five attempts', async () => {
@@ -634,7 +663,7 @@ describe('OPS-13 transient voice recovery', () => {
     const player = new Player({} as never, GUILD_ID);
     player.voiceConnection = connection as never;
 
-    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect();
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect(connection);
     expect(dependencyMocks.sleep).toHaveBeenCalledWith(15_000);
     backoff.resolve(undefined);
     await recovery;
@@ -654,7 +683,7 @@ describe('OPS-13 transient voice recovery', () => {
     const player = new Player({} as never, GUILD_ID);
     player.voiceConnection = connection as never;
 
-    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect();
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect(connection);
     expect(dependencyMocks.sleep).toHaveBeenCalledWith(10_000);
 
     connection.state.status = 'ready';
@@ -666,6 +695,33 @@ describe('OPS-13 transient voice recovery', () => {
     expect(player.voiceConnection).toBe(connection);
   });
 
+  it('does not rejoin or destroy a replacement when an old transient backoff later releases', async () => {
+    const backoff = makeDeferred<void>();
+    dependencyMocks.sleep.mockReturnValue(backoff.promise);
+    const {connection: oldConnection} = makeVoiceConnection({
+      rejoinAttempts: 1,
+      state: {status: 'disconnected'},
+    });
+    const {connection: replacement} = makeVoiceConnection({
+      rejoinAttempts: 0,
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = oldConnection as never;
+
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect(oldConnection);
+    expect(dependencyMocks.sleep).toHaveBeenCalledWith(10_000);
+    player.voiceConnection = replacement as never;
+    backoff.resolve(undefined);
+    await recovery;
+
+    expect(oldConnection.rejoin).not.toHaveBeenCalled();
+    expect(oldConnection.destroy).not.toHaveBeenCalled();
+    expect(replacement.rejoin).not.toHaveBeenCalled();
+    expect(replacement.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(replacement);
+  });
+
   it('destroys a still-disconnected connection when rejoin fails below five attempts', async () => {
     const {connection} = makeVoiceConnection({
       rejoin: vi.fn(() => false),
@@ -675,7 +731,7 @@ describe('OPS-13 transient voice recovery', () => {
     const player = new Player({} as never, GUILD_ID);
     player.voiceConnection = connection as never;
 
-    await getPrivatePlayer(player).onVoiceConnectionDisconnect();
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect(connection);
 
     expect(dependencyMocks.sleep).toHaveBeenCalledWith(5_000);
     expect(connection.rejoin).toHaveBeenCalledOnce();
@@ -691,12 +747,61 @@ describe('OPS-13 transient voice recovery', () => {
     const player = new Player({} as never, GUILD_ID);
     player.voiceConnection = connection as never;
 
-    await getPrivatePlayer(player).onVoiceConnectionDisconnect();
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect(connection);
 
     expect(dependencyMocks.sleep).not.toHaveBeenCalled();
     expect(connection.rejoin).not.toHaveBeenCalled();
     expect(connection.destroy).toHaveBeenCalledOnce();
     expect(player.voiceConnection).toBeNull();
+  });
+
+  it('keeps a newer connection when an older initial Ready wait rejects and ignores the old Ready callback', async () => {
+    const readyA = makeDeferred<void>();
+    const readyB = makeDeferred<void>();
+    const {connection: connectionA, handlers: handlersA} = makeVoiceConnection({
+      rejoinAttempts: 2,
+      state: {status: 'connecting'},
+    });
+    const {connection: connectionB} = makeVoiceConnection({
+      state: {status: 'connecting'},
+    });
+    dependencyMocks.joinVoiceChannel
+      .mockReturnValueOnce(connectionA)
+      .mockReturnValueOnce(connectionB);
+    dependencyMocks.entersState.mockImplementation((_connection: unknown) => (
+      _connection === connectionA ? readyA.promise : readyB.promise
+    ));
+    const player = new Player({} as never, GUILD_ID);
+    const registerVoiceActivityListener = vi.spyOn(player, 'registerVoiceActivityListener');
+    const channelA = {
+      id: 'voice-channel-a',
+      guild: {id: GUILD_ID, voiceAdapterCreator: {}},
+    };
+    const channelB = {
+      id: 'voice-channel-b',
+      guild: {id: GUILD_ID, voiceAdapterCreator: {}},
+    };
+
+    const connectingA = player.connect(channelA as never);
+    await flushAsyncWork();
+    const connectingB = player.connect(channelB as never);
+    await flushAsyncWork();
+    expect(player.voiceConnection).toBe(connectionB);
+
+    handlersA.get('stateChange')!({status: 'connecting'}, {status: 'ready'});
+    connectionA.state.status = 'disconnected';
+    readyA.reject(new Error('connection A Ready timeout'));
+    await expect(connectingA).rejects.toThrow(
+      'Failed to connect to the voice channel (last state: disconnected, rejoin attempts: 2, recent states: connecting -> ready).',
+    );
+
+    readyB.resolve(undefined);
+    await connectingB;
+
+    expect(connectionA.destroy).toHaveBeenCalled();
+    expect(connectionB.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(connectionB);
+    expect(registerVoiceActivityListener).not.toHaveBeenCalled();
   });
 
   it('uses a 60-second initial Ready wait and preserves status, attempts, and recent-state diagnostics', async () => {

--- a/tests/ops-integrations.test.ts
+++ b/tests/ops-integrations.test.ts
@@ -647,6 +647,52 @@ describe('OPS-13 transient voice recovery', () => {
     oldRecovery.reject(new Error('old 4014 recovery timed out'));
     await recovery;
 
+    expect(oldConnection.destroy).toHaveBeenCalledOnce();
+    expect(replacement.rejoin).not.toHaveBeenCalled();
+    expect(replacement.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(replacement);
+  });
+
+  it('cleans up an old 4014 connection that recovers after it was replaced', async () => {
+    const oldRecovery = makeDeferred<void>();
+    dependencyMocks.entersState.mockReturnValue(oldRecovery.promise);
+    const {connection: oldConnection} = makeVoiceConnection({
+      state: {
+        status: 'disconnected',
+        reason: 'websocket-close',
+        closeCode: 4014,
+      },
+    });
+    const {connection: replacement} = makeVoiceConnection({
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = oldConnection as never;
+
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect(oldConnection);
+    await flushAsyncWork();
+    player.voiceConnection = replacement as never;
+    oldRecovery.resolve(undefined);
+    await recovery;
+
+    expect(oldConnection.destroy).toHaveBeenCalledOnce();
+    expect(replacement.rejoin).not.toHaveBeenCalled();
+    expect(replacement.destroy).not.toHaveBeenCalled();
+    expect(player.voiceConnection).toBe(replacement);
+  });
+
+  it('does not destroy an already Destroyed stale connection or touch its replacement', async () => {
+    const {connection: oldConnection} = makeVoiceConnection({
+      state: {status: 'destroyed'},
+    });
+    const {connection: replacement} = makeVoiceConnection({
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    player.voiceConnection = replacement as never;
+
+    await getPrivatePlayer(player).onVoiceConnectionDisconnect(oldConnection);
+
     expect(oldConnection.destroy).not.toHaveBeenCalled();
     expect(replacement.rejoin).not.toHaveBeenCalled();
     expect(replacement.destroy).not.toHaveBeenCalled();
@@ -695,6 +741,41 @@ describe('OPS-13 transient voice recovery', () => {
     expect(player.voiceConnection).toBe(connection);
   });
 
+  it('clears a current connection that becomes Destroyed during transient backoff without destroying it again', async () => {
+    const backoff = makeDeferred<void>();
+    dependencyMocks.sleep.mockReturnValue(backoff.promise);
+    const {connection} = makeVoiceConnection({
+      rejoinAttempts: 1,
+      state: {status: 'disconnected'},
+    });
+    const player = new Player({} as never, GUILD_ID);
+    const audioPlayer = {stop: vi.fn()};
+    player.voiceConnection = connection as never;
+    Object.assign(player, {
+      audioPlayer,
+      audioResource: {volume: {}},
+      currentChannel: {id: 'old-channel'},
+    });
+
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect(connection);
+    connection.state.status = 'destroyed';
+    backoff.resolve(undefined);
+    await recovery;
+
+    const state = player as unknown as {
+      audioPlayer: object | null;
+      audioResource: object | null;
+      currentChannel?: object;
+    };
+    expect(connection.destroy).not.toHaveBeenCalled();
+    expect(connection.rejoin).not.toHaveBeenCalled();
+    expect(audioPlayer.stop).toHaveBeenCalledWith(true);
+    expect(player.voiceConnection).toBeNull();
+    expect(state.audioPlayer).toBeNull();
+    expect(state.audioResource).toBeNull();
+    expect(state.currentChannel).toBeUndefined();
+  });
+
   it('does not rejoin or destroy a replacement when an old transient backoff later releases', async () => {
     const backoff = makeDeferred<void>();
     dependencyMocks.sleep.mockReturnValue(backoff.promise);
@@ -716,10 +797,48 @@ describe('OPS-13 transient voice recovery', () => {
     await recovery;
 
     expect(oldConnection.rejoin).not.toHaveBeenCalled();
-    expect(oldConnection.destroy).not.toHaveBeenCalled();
+    expect(oldConnection.destroy).toHaveBeenCalledOnce();
     expect(replacement.rejoin).not.toHaveBeenCalled();
     expect(replacement.destroy).not.toHaveBeenCalled();
     expect(player.voiceConnection).toBe(replacement);
+  });
+
+  it('clears a current 4014 connection already Destroyed when its recovery wait rejects', async () => {
+    const oldRecovery = makeDeferred<void>();
+    dependencyMocks.entersState.mockReturnValue(oldRecovery.promise);
+    const {connection} = makeVoiceConnection({
+      state: {
+        status: 'disconnected',
+        reason: 'websocket-close',
+        closeCode: 4014,
+      },
+    });
+    const player = new Player({} as never, GUILD_ID);
+    const audioPlayer = {stop: vi.fn()};
+    player.voiceConnection = connection as never;
+    Object.assign(player, {
+      audioPlayer,
+      audioResource: {volume: {}},
+      currentChannel: {id: 'old-channel'},
+    });
+
+    const recovery = getPrivatePlayer(player).onVoiceConnectionDisconnect(connection);
+    await flushAsyncWork();
+    connection.state.status = 'destroyed';
+    oldRecovery.reject(new Error('4014 recovery ended after destruction'));
+    await recovery;
+
+    const state = player as unknown as {
+      audioPlayer: object | null;
+      audioResource: object | null;
+      currentChannel?: object;
+    };
+    expect(connection.destroy).not.toHaveBeenCalled();
+    expect(audioPlayer.stop).toHaveBeenCalledWith(true);
+    expect(player.voiceConnection).toBeNull();
+    expect(state.audioPlayer).toBeNull();
+    expect(state.audioResource).toBeNull();
+    expect(state.currentChannel).toBeUndefined();
   });
 
   it('destroys a still-disconnected connection when rejoin fails below five attempts', async () => {

--- a/tests/ops-persistence.test.ts
+++ b/tests/ops-persistence.test.ts
@@ -1,0 +1,720 @@
+import Prisma from '@prisma/client';
+import {execa} from 'execa';
+import {promises as fs} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {describe, expect, it, vi} from 'vitest';
+
+describe('migration orchestration', () => {
+  it('derives absolute, relative, and escaped Windows paths without query parameters', async () => {
+    const {createDatabasePathFromUrl} = await import('../src/utils/create-database-url.js');
+
+    expect(createDatabasePathFromUrl('file:/srv/muse/db.sqlite?socket_timeout=10&connection_limit=1'))
+      .toBe('/srv/muse/db.sqlite');
+    expect(createDatabasePathFromUrl('file:./data/db.sqlite?connection_limit=1'))
+      .toBe('./data/db.sqlite');
+    expect(createDatabasePathFromUrl('file:C:\\\\Muse Data\\\\db.sqlite?connection_limit=1', 'win32'))
+      .toBe('C:\\Muse Data\\db.sqlite');
+  });
+
+  it('deploys a fresh database, reports success, and starts without legacy probes', async () => {
+    const {runMigrationsAndStart} = await import('../src/utils/run-migrations-and-start.js');
+    const sequence: string[] = [];
+    const hasPrismaMigrations = vi.fn();
+    const resolveInitialMigration = vi.fn();
+
+    await runMigrationsAndStart({
+      databaseExists: vi.fn(async () => {
+        sequence.push('exists');
+        return false;
+      }),
+      deployMigrations: vi.fn(async () => {
+        sequence.push('deploy');
+      }),
+      hasPrismaMigrations,
+      migrationsApplied: vi.fn(() => {
+        sequence.push('success');
+      }),
+      resolveInitialMigration,
+      startBot: vi.fn(async () => {
+        sequence.push('start');
+      }),
+    });
+
+    expect(sequence).toEqual(['exists', 'deploy', 'success', 'start']);
+    expect(hasPrismaMigrations).not.toHaveBeenCalled();
+    expect(resolveInitialMigration).not.toHaveBeenCalled();
+  });
+
+  it('resolves the initial migration before deploying and starting a pre-Prisma database', async () => {
+    const {runMigrationsAndStart} = await import('../src/utils/run-migrations-and-start.js');
+    const sequence: string[] = [];
+
+    await runMigrationsAndStart({
+      databaseExists: vi.fn(async () => {
+        sequence.push('exists');
+        return true;
+      }),
+      hasPrismaMigrations: vi.fn(async () => {
+        sequence.push('unmigrated');
+        return false;
+      }),
+      resolveInitialMigration: vi.fn(async () => {
+        sequence.push('resolve');
+      }),
+      deployMigrations: vi.fn(async () => {
+        sequence.push('deploy');
+      }),
+      migrationsApplied: vi.fn(() => {
+        sequence.push('success');
+      }),
+      startBot: vi.fn(async () => {
+        sequence.push('start');
+      }),
+    });
+
+    expect(sequence).toEqual(['exists', 'unmigrated', 'resolve', 'deploy', 'success', 'start']);
+  });
+
+  it('skips initial resolution for an already-migrated database', async () => {
+    const {runMigrationsAndStart} = await import('../src/utils/run-migrations-and-start.js');
+    const sequence: string[] = [];
+    const resolveInitialMigration = vi.fn();
+
+    await runMigrationsAndStart({
+      databaseExists: vi.fn(async () => {
+        sequence.push('exists');
+        return true;
+      }),
+      hasPrismaMigrations: vi.fn(async () => {
+        sequence.push('migrated');
+        return true;
+      }),
+      resolveInitialMigration,
+      deployMigrations: vi.fn(async () => {
+        sequence.push('deploy');
+      }),
+      migrationsApplied: vi.fn(() => {
+        sequence.push('success');
+      }),
+      startBot: vi.fn(async () => {
+        sequence.push('start');
+      }),
+    });
+
+    expect(sequence).toEqual(['exists', 'migrated', 'deploy', 'success', 'start']);
+    expect(resolveInitialMigration).not.toHaveBeenCalled();
+  });
+
+  it('does not deploy, report success, or start when initial resolution fails', async () => {
+    const {runMigrationsAndStart} = await import('../src/utils/run-migrations-and-start.js');
+    const failure = new Error('initial resolution failed');
+    const deployMigrations = vi.fn();
+    const migrationsApplied = vi.fn();
+    const startBot = vi.fn();
+
+    await expect(runMigrationsAndStart({
+      databaseExists: vi.fn().mockResolvedValue(true),
+      deployMigrations,
+      hasPrismaMigrations: vi.fn().mockResolvedValue(false),
+      migrationsApplied,
+      resolveInitialMigration: vi.fn().mockRejectedValue(failure),
+      startBot,
+    })).rejects.toBe(failure);
+
+    expect(deployMigrations).not.toHaveBeenCalled();
+    expect(migrationsApplied).not.toHaveBeenCalled();
+    expect(startBot).not.toHaveBeenCalled();
+  });
+
+  it('does not report success or start when deployment fails', async () => {
+    const {runMigrationsAndStart} = await import('../src/utils/run-migrations-and-start.js');
+    const failure = new Error('migration failed');
+    const migrationsApplied = vi.fn();
+    const startBot = vi.fn();
+
+    await expect(runMigrationsAndStart({
+      databaseExists: vi.fn().mockResolvedValue(false),
+      deployMigrations: vi.fn().mockRejectedValue(failure),
+      hasPrismaMigrations: vi.fn(),
+      migrationsApplied,
+      resolveInitialMigration: vi.fn(),
+      startBot,
+    })).rejects.toBe(failure);
+
+    expect(migrationsApplied).not.toHaveBeenCalled();
+    expect(startBot).not.toHaveBeenCalled();
+  });
+
+  it('detects an explicit SQLite DATABASE_URL instead of the default DATA_DIR database', async () => {
+    const explicitDatabasePath = path.join(os.tmpdir(), 'explicit-muse.sqlite');
+    const originalDatabaseUrl = process.env.DATABASE_URL;
+    const access = vi.fn().mockResolvedValue(undefined);
+    const startBot = vi.fn().mockResolvedValue(undefined);
+    const queryRaw = vi.fn().mockResolvedValue([{count: 1}]);
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    const spinner = {
+      fail: vi.fn(),
+      start: vi.fn(),
+      succeed: vi.fn(),
+    };
+    spinner.start.mockReturnValue(spinner);
+
+    vi.resetModules();
+    vi.doMock('fs', () => ({promises: {access}}));
+    vi.doMock('ora', () => ({default: vi.fn(() => spinner)}));
+    vi.doMock('execa', () => ({execa: vi.fn().mockResolvedValue(undefined)}));
+    vi.doMock('@prisma/client', () => ({
+      default: {
+        Prisma: {PrismaClientKnownRequestError: class extends Error {}},
+        PrismaClient: class {
+          $disconnect = disconnect;
+          $queryRaw = queryRaw;
+        },
+      },
+    }));
+    vi.doMock('../src/index.js', () => ({startBot}));
+    vi.doMock('../src/services/config.js', () => ({DATA_DIR: path.join(os.tmpdir(), 'default-muse-data')}));
+    vi.doMock('../src/utils/log-banner.js', () => ({default: vi.fn()}));
+    process.env.DATABASE_URL = `file:${explicitDatabasePath}?socket_timeout=10&connection_limit=1`;
+
+    try {
+      await import('../src/scripts/migrate-and-start.js');
+      await vi.waitFor(() => {
+        expect(startBot).toHaveBeenCalledOnce();
+      });
+
+      expect(access).toHaveBeenCalledWith(explicitDatabasePath);
+    } finally {
+      if (originalDatabaseUrl === undefined) {
+        delete process.env.DATABASE_URL;
+      } else {
+        process.env.DATABASE_URL = originalDatabaseUrl;
+      }
+
+      vi.doUnmock('fs');
+      vi.doUnmock('ora');
+      vi.doUnmock('execa');
+      vi.doUnmock('@prisma/client');
+      vi.doUnmock('../src/index.js');
+      vi.doUnmock('../src/services/config.js');
+      vi.doUnmock('../src/utils/log-banner.js');
+      vi.resetModules();
+    }
+  });
+});
+
+describe('SQLite persistence', () => {
+  it('resolves and deploys a real pre-Prisma SQLite database before the start callback', async () => {
+    const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'muse-legacy-migration-'));
+    const databasePath = path.join(tempDirectory, 'db.sqlite');
+    const databaseUrl = `file:${databasePath}?socket_timeout=10&connection_limit=1`;
+    const prismaEnvironment = {...process.env, DATABASE_URL: databaseUrl, RUST_LOG: 'info'};
+    let probeClient: InstanceType<typeof Prisma.PrismaClient> | undefined;
+    let reopenedClient: InstanceType<typeof Prisma.PrismaClient> | undefined;
+
+    try {
+      await execa('prisma', [
+        'db',
+        'execute',
+        '--file',
+        'migrations/20220101155430_migrate_from_sequelize/migration.sql',
+        '--schema',
+        'schema.prisma',
+      ], {
+        env: prismaEnvironment,
+        preferLocal: true,
+        timeout: 15_000,
+      });
+      probeClient = new Prisma.PrismaClient({
+        datasources: {db: {url: databaseUrl}},
+      });
+      const legacyTables = await probeClient.$queryRawUnsafe<Array<{name: string}>>(
+        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+      );
+      expect(legacyTables.map(({name}) => name)).toEqual(expect.arrayContaining([
+        'FileCaches',
+        'KeyValueCaches',
+        'Settings',
+      ]));
+      expect(legacyTables.map(({name}) => name)).not.toContain('_prisma_migrations');
+
+      const {runMigrationsAndStart} = await import('../src/utils/run-migrations-and-start.js');
+      const sequence: string[] = [];
+      await runMigrationsAndStart({
+        databaseExists: async () => {
+          sequence.push('exists');
+          await fs.access(databasePath);
+          return true;
+        },
+        hasPrismaMigrations: async () => {
+          sequence.push('unmigrated');
+          try {
+            await probeClient!.$queryRawUnsafe('SELECT COUNT(id) FROM _prisma_migrations');
+            return true;
+          } catch (error: unknown) {
+            expect(error).toMatchObject({code: 'P2010'});
+            return false;
+          } finally {
+            await probeClient!.$disconnect();
+            probeClient = undefined;
+          }
+        },
+        resolveInitialMigration: async () => {
+          sequence.push('resolve');
+          await execa('prisma', [
+            'migrate',
+            'resolve',
+            '--applied',
+            '20220101155430_migrate_from_sequelize',
+          ], {
+            env: prismaEnvironment,
+            preferLocal: true,
+            timeout: 15_000,
+          });
+        },
+        deployMigrations: async () => {
+          sequence.push('deploy');
+          await execa('prisma', ['migrate', 'deploy'], {
+            env: prismaEnvironment,
+            preferLocal: true,
+            timeout: 15_000,
+          });
+        },
+        migrationsApplied: () => {
+          sequence.push('success');
+        },
+        startBot: async () => {
+          sequence.push('start');
+          reopenedClient = new Prisma.PrismaClient({
+            datasources: {db: {url: databaseUrl}},
+          });
+          await Promise.all([
+            reopenedClient.setting.count(),
+            reopenedClient.favoriteQuery.count(),
+            reopenedClient.fileCache.count(),
+            reopenedClient.keyValueCache.count(),
+          ]);
+        },
+      });
+
+      expect(sequence).toEqual(['exists', 'unmigrated', 'resolve', 'deploy', 'success', 'start']);
+      const appliedMigrations = await reopenedClient!.$queryRawUnsafe<Array<{
+        finished_at: Date | null;
+        migration_name: string;
+      }>>('SELECT migration_name, finished_at FROM _prisma_migrations ORDER BY migration_name');
+      expect(appliedMigrations).toHaveLength(19);
+      expect(appliedMigrations.every(({finished_at: finishedAt}) => finishedAt !== null)).toBe(true);
+      expect(appliedMigrations.map(({migration_name: name}) => name))
+        .toContain('20220101155430_migrate_from_sequelize');
+    } finally {
+      await probeClient?.$disconnect();
+      await reopenedClient?.$disconnect();
+      await fs.rm(tempDirectory, {force: true, recursive: true});
+    }
+  }, 30_000);
+
+  it('reopens every durable model while a fresh PlayerManager starts with an empty in-memory queue', async () => {
+    const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'muse-ops-persistence-'));
+    const databasePath = path.join(tempDirectory, 'db.sqlite');
+    const databaseUrl = `file:${databasePath}?socket_timeout=10&connection_limit=1`;
+    const originalDatabaseUrl = process.env.DATABASE_URL;
+    let firstClient: InstanceType<typeof Prisma.PrismaClient> | undefined;
+    let reopenedClient: InstanceType<typeof Prisma.PrismaClient> | undefined;
+
+    try {
+      await execa('prisma', ['migrate', 'deploy'], {
+        env: {...process.env, DATABASE_URL: databaseUrl, RUST_LOG: 'info'},
+        preferLocal: true,
+        timeout: 15_000,
+      });
+
+      firstClient = new Prisma.PrismaClient({
+        datasources: {db: {url: databaseUrl}},
+      });
+      const accessedAt = new Date('2026-07-12T12:00:00.000Z');
+      const expiresAt = new Date('2026-07-12T13:00:00.000Z');
+
+      await firstClient.setting.create({
+        data: {guildId: 'persistent-guild', playlistLimit: 37},
+      });
+      await firstClient.favoriteQuery.create({
+        data: {
+          authorId: 'persistent-author',
+          guildId: 'persistent-guild',
+          name: 'persistent-favorite',
+          query: 'persistent query',
+        },
+      });
+      await firstClient.fileCache.create({
+        data: {accessedAt, bytes: 1234, hash: 'persistent-file-hash'},
+      });
+      await firstClient.keyValueCache.create({
+        data: {expiresAt, key: 'persistent-key', value: JSON.stringify({answer: 42})},
+      });
+      await firstClient.$disconnect();
+      firstClient = undefined;
+
+      reopenedClient = new Prisma.PrismaClient({
+        datasources: {db: {url: databaseUrl}},
+      });
+
+      await expect(reopenedClient.setting.findUnique({where: {guildId: 'persistent-guild'}}))
+        .resolves.toEqual(expect.objectContaining({guildId: 'persistent-guild', playlistLimit: 37}));
+      await expect(reopenedClient.favoriteQuery.findUnique({
+        where: {guildId_name: {guildId: 'persistent-guild', name: 'persistent-favorite'}},
+      })).resolves.toEqual(expect.objectContaining({
+        authorId: 'persistent-author',
+        query: 'persistent query',
+      }));
+      await expect(reopenedClient.fileCache.findUnique({where: {hash: 'persistent-file-hash'}}))
+        .resolves.toEqual(expect.objectContaining({accessedAt, bytes: 1234}));
+      await expect(reopenedClient.keyValueCache.findUnique({where: {key: 'persistent-key'}}))
+        .resolves.toEqual(expect.objectContaining({expiresAt, value: JSON.stringify({answer: 42})}));
+
+      process.env.DATABASE_URL = databaseUrl;
+      vi.doMock('../src/utils/get-guild-settings.js', () => ({
+        getGuildSettings: vi.fn(),
+      }));
+      const {default: PlayerManager} = await import('../src/managers/player.js');
+      const fileCache = {};
+      const youtubeAPI = {findAudioFallback: vi.fn().mockResolvedValue(null)};
+      const firstManager = new PlayerManager(fileCache as never, youtubeAPI as never);
+      firstManager.get('persistent-guild').add({
+        addedInChannelId: 'persistent-channel',
+        artist: 'Persistent artist',
+        isLive: false,
+        length: 180,
+        offset: 0,
+        playlist: null,
+        requestedBy: 'persistent-author',
+        source: 0,
+        thumbnailUrl: null,
+        title: 'Only in memory',
+        url: 'persistent-video',
+      });
+
+      const reopenedManager = new PlayerManager(fileCache as never, youtubeAPI as never);
+      expect(firstManager.get('persistent-guild').getCurrent()?.title).toBe('Only in memory');
+      expect(reopenedManager.get('persistent-guild').getCurrent()).toBeNull();
+      expect(reopenedManager.get('persistent-guild').getQueue()).toEqual([]);
+    } finally {
+      const restoreEnvironment = (name: string, value: string | undefined) => {
+        if (value === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = value;
+        }
+      };
+
+      restoreEnvironment('DATABASE_URL', originalDatabaseUrl);
+      vi.doUnmock('../src/utils/get-guild-settings.js');
+      await firstClient?.$disconnect();
+      await reopenedClient?.$disconnect();
+      await fs.rm(tempDirectory, {force: true, recursive: true});
+    }
+  }, 20_000);
+
+  it('runs the supported clear command against only KeyValueCache rows', async () => {
+    const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'muse-cache-clear-'));
+    const databasePath = path.join(tempDirectory, 'db.sqlite');
+    const databaseUrl = `file:${databasePath}?socket_timeout=10&connection_limit=1`;
+    let seedClient: InstanceType<typeof Prisma.PrismaClient> | undefined;
+    let reopenedClient: InstanceType<typeof Prisma.PrismaClient> | undefined;
+
+    try {
+      await execa('prisma', ['migrate', 'deploy'], {
+        env: {...process.env, DATABASE_URL: databaseUrl, RUST_LOG: 'info'},
+        preferLocal: true,
+        timeout: 15_000,
+      });
+      seedClient = new Prisma.PrismaClient({
+        datasources: {db: {url: databaseUrl}},
+      });
+      await seedClient.setting.create({
+        data: {guildId: 'cache-clear-guild', playlistLimit: 23},
+      });
+      await seedClient.favoriteQuery.create({
+        data: {
+          authorId: 'cache-clear-author',
+          guildId: 'cache-clear-guild',
+          name: 'cache-clear-favorite',
+          query: 'keep this favorite',
+        },
+      });
+      await seedClient.fileCache.create({
+        data: {
+          accessedAt: new Date('2026-07-12T15:00:00.000Z'),
+          bytes: 2048,
+          hash: 'cache-clear-file',
+        },
+      });
+      await seedClient.keyValueCache.create({
+        data: {
+          expiresAt: new Date('2026-07-12T16:00:00.000Z'),
+          key: 'cache-clear-key',
+          value: JSON.stringify({remove: true}),
+        },
+      });
+      await seedClient.$disconnect();
+      seedClient = undefined;
+
+      await execa('npm', ['run', 'cache:clear-key-value'], {
+        cwd: process.cwd(),
+        env: {...process.env, DATABASE_URL: databaseUrl},
+        timeout: 15_000,
+      });
+
+      reopenedClient = new Prisma.PrismaClient({
+        datasources: {db: {url: databaseUrl}},
+      });
+      await expect(Promise.all([
+        reopenedClient.setting.count(),
+        reopenedClient.favoriteQuery.count(),
+        reopenedClient.fileCache.count(),
+        reopenedClient.keyValueCache.count(),
+      ])).resolves.toEqual([1, 1, 1, 0]);
+      await expect(reopenedClient.setting.findUnique({where: {guildId: 'cache-clear-guild'}}))
+        .resolves.toEqual(expect.objectContaining({playlistLimit: 23}));
+      await expect(reopenedClient.favoriteQuery.findUnique({
+        where: {guildId_name: {guildId: 'cache-clear-guild', name: 'cache-clear-favorite'}},
+      })).resolves.toEqual(expect.objectContaining({query: 'keep this favorite'}));
+      await expect(reopenedClient.fileCache.findUnique({where: {hash: 'cache-clear-file'}}))
+        .resolves.toEqual(expect.objectContaining({bytes: 2048}));
+    } finally {
+      await seedClient?.$disconnect();
+      await reopenedClient?.$disconnect();
+      await fs.rm(tempDirectory, {force: true, recursive: true});
+    }
+  }, 25_000);
+});
+
+const makeKeyValueCacheModel = () => ({
+  delete: vi.fn(),
+  findUnique: vi.fn(),
+  upsert: vi.fn(),
+});
+
+const loadKeyValueCache = async (keyValueCache: ReturnType<typeof makeKeyValueCacheModel>) => {
+  vi.resetModules();
+  vi.doMock('../src/utils/db.js', () => ({
+    prisma: {keyValueCache},
+  }));
+  vi.doMock('../src/utils/debug.js', () => ({default: vi.fn()}));
+  const {default: KeyValueCacheProvider} = await import('../src/services/key-value-cache.js');
+
+  return new KeyValueCacheProvider();
+};
+
+const resetKeyValueCacheHarness = () => {
+  vi.useRealTimers();
+  vi.doUnmock('../src/utils/db.js');
+  vi.doUnmock('../src/utils/debug.js');
+  vi.resetModules();
+};
+
+describe('KeyValueCacheProvider expiration and persistence', () => {
+  it('returns an unexpired parsed JSON hit without invoking or rewriting it', async () => {
+    vi.useFakeTimers({toFake: ['Date']});
+    vi.setSystemTime(new Date('2026-07-12T14:00:00.000Z'));
+    const model = makeKeyValueCacheModel();
+    model.findUnique.mockResolvedValue({
+      expiresAt: new Date('2026-07-12T14:00:01.000Z'),
+      key: 'unexpired-key',
+      value: JSON.stringify({nested: ['cached', 42]}),
+    });
+    const wrapped = vi.fn().mockResolvedValue({wrong: true});
+
+    try {
+      const cache = await loadKeyValueCache(model);
+
+      await expect(cache.wrap(wrapped, {expiresIn: 60, key: 'unexpired-key'}))
+        .resolves.toEqual({nested: ['cached', 42]});
+      expect(wrapped).not.toHaveBeenCalled();
+      expect(model.delete).not.toHaveBeenCalled();
+      expect(model.upsert).not.toHaveBeenCalled();
+    } finally {
+      resetKeyValueCacheHarness();
+    }
+  });
+
+  it('deletes an expired row before refreshing and persists the replacement JSON', async () => {
+    vi.useFakeTimers({toFake: ['Date']});
+    vi.setSystemTime(new Date('2026-07-12T14:00:00.000Z'));
+    const model = makeKeyValueCacheModel();
+    model.findUnique.mockResolvedValue({
+      expiresAt: new Date('2026-07-12T13:59:59.999Z'),
+      key: 'expired-key',
+      value: JSON.stringify({stale: true}),
+    });
+    model.delete.mockResolvedValue({});
+    model.upsert.mockResolvedValue({});
+    const wrapped = vi.fn().mockImplementation(async () => {
+      expect(model.delete).toHaveBeenCalledWith({where: {key: 'expired-key'}});
+      return {fresh: true};
+    });
+
+    try {
+      const cache = await loadKeyValueCache(model);
+
+      await expect(cache.wrap(wrapped, {expiresIn: 30, key: 'expired-key'}))
+        .resolves.toEqual({fresh: true});
+      expect(model.upsert).toHaveBeenCalledWith({
+        where: {key: 'expired-key'},
+        update: {
+          expiresAt: new Date('2026-07-12T14:00:30.000Z'),
+          value: JSON.stringify({fresh: true}),
+        },
+        create: {
+          expiresAt: new Date('2026-07-12T14:00:30.000Z'),
+          key: 'expired-key',
+          value: JSON.stringify({fresh: true}),
+        },
+      });
+    } finally {
+      resetKeyValueCacheHarness();
+    }
+  });
+
+  it('upserts a cache miss as JSON with the exact requested expiration', async () => {
+    vi.useFakeTimers({toFake: ['Date']});
+    vi.setSystemTime(new Date('2026-07-12T14:00:00.000Z'));
+    const model = makeKeyValueCacheModel();
+    model.findUnique.mockResolvedValue(null);
+    model.upsert.mockResolvedValue({});
+    const result = {items: [{id: 1}], nullable: null};
+
+    try {
+      const cache = await loadKeyValueCache(model);
+
+      await expect(cache.wrap(vi.fn().mockResolvedValue(result), {expiresIn: 75, key: 'cache-miss-key'}))
+        .resolves.toEqual(result);
+      expect(model.delete).not.toHaveBeenCalled();
+      expect(model.upsert).toHaveBeenCalledWith({
+        where: {key: 'cache-miss-key'},
+        update: {
+          expiresAt: new Date('2026-07-12T14:01:15.000Z'),
+          value: JSON.stringify(result),
+        },
+        create: {
+          expiresAt: new Date('2026-07-12T14:01:15.000Z'),
+          key: 'cache-miss-key',
+          value: JSON.stringify(result),
+        },
+      });
+    } finally {
+      resetKeyValueCacheHarness();
+    }
+  });
+});
+
+describe('key-value cache TTL call-site contracts', () => {
+  it('uses one hour for search, details, autocomplete, and SponsorBlock, but one minute for playlist reads', async () => {
+    vi.resetModules();
+    vi.doMock('../src/utils/db.js', () => ({prisma: {}}));
+    vi.doMock('../src/utils/get-guild-settings.js', () => ({getGuildSettings: vi.fn()}));
+    vi.doMock('sponsorblock-api', () => ({
+      SponsorBlock: class {
+        async getSegments() {
+          return [];
+        }
+      },
+    }));
+
+    try {
+      const [
+        {default: YoutubeAPI},
+        {default: Play},
+        {default: AddQueryToQueue},
+      ] = await Promise.all([
+        import('../src/services/youtube-api.js'),
+        import('../src/commands/play.js'),
+        import('../src/services/add-query-to-queue.js'),
+      ]);
+      const video = {
+        contentDetails: {duration: 'PT3M', videoId: 'video-id'},
+        id: 'video-id',
+        snippet: {
+          channelTitle: 'Test artist',
+          description: '',
+          liveBroadcastContent: 'none',
+          thumbnails: {medium: {url: 'https://img.example/video.jpg'}},
+          title: 'Test song',
+        },
+      };
+
+      const searchCache = {
+        wrap: vi.fn()
+          .mockResolvedValueOnce({items: [{id: {videoId: 'video-id'}}]})
+          .mockResolvedValueOnce({items: [video]}),
+      };
+      const searchApi = new YoutubeAPI({YOUTUBE_API_KEY: 'isolated-key'} as never, searchCache as never);
+      await searchApi.search('isolated query', false);
+
+      const playlistCache = {
+        wrap: vi.fn()
+          .mockResolvedValueOnce({
+            items: [{
+              contentDetails: {itemCount: 1},
+              id: 'playlist-id',
+              snippet: {title: 'Test playlist'},
+            }],
+          })
+          .mockResolvedValueOnce({
+            items: [{contentDetails: {videoId: 'video-id'}, id: 'playlist-item-id'}],
+          })
+          .mockResolvedValueOnce({items: [video]}),
+      };
+      const playlistApi = new YoutubeAPI({YOUTUBE_API_KEY: 'isolated-key'} as never, playlistCache as never);
+      await playlistApi.getPlaylist('playlist-id', false);
+
+      const autocompleteCache = {wrap: vi.fn().mockResolvedValue([])};
+      const play = new Play(undefined as never, autocompleteCache as never, {} as never);
+      const autocompleteInteraction = {
+        options: {getString: vi.fn(() => 'isolated query')},
+        respond: vi.fn().mockResolvedValue(undefined),
+      };
+      await play.handleAutocompleteInteraction(autocompleteInteraction as never);
+
+      const sponsorBlockCache = {wrap: vi.fn().mockResolvedValue([])};
+      const addQueryToQueue = new AddQueryToQueue(
+        {} as never,
+        {} as never,
+        {ENABLE_SPONSORBLOCK: true, SPONSORBLOCK_TIMEOUT: 5} as never,
+        sponsorBlockCache as never,
+      );
+      await (addQueryToQueue as unknown as {
+        skipNonMusicSegments(song: object): Promise<object>;
+      }).skipNonMusicSegments({
+        artist: 'Test artist',
+        isLive: false,
+        length: 180,
+        offset: 0,
+        playlist: null,
+        source: 0,
+        thumbnailUrl: null,
+        title: 'Test song',
+        url: 'video-id',
+      });
+
+      const expirationValues = (cacheWrap: ReturnType<typeof vi.fn>) => cacheWrap.mock.calls
+        .map(call => (call.at(-1) as {expiresIn: number}).expiresIn);
+      expect({
+        autocomplete: expirationValues(autocompleteCache.wrap),
+        playlistMetadataItemsAndDetails: expirationValues(playlistCache.wrap),
+        searchAndDetails: expirationValues(searchCache.wrap),
+        sponsorBlock: expirationValues(sponsorBlockCache.wrap),
+      }).toEqual({
+        autocomplete: [3600],
+        playlistMetadataItemsAndDetails: [60, 60, 3600],
+        searchAndDetails: [3600, 3600],
+        sponsorBlock: [3600],
+      });
+    } finally {
+      vi.doUnmock('../src/utils/db.js');
+      vi.doUnmock('../src/utils/get-guild-settings.js');
+      vi.doUnmock('sponsorblock-api');
+      vi.resetModules();
+    }
+  });
+});

--- a/tests/ops-startup.test.ts
+++ b/tests/ops-startup.test.ts
@@ -1,0 +1,352 @@
+import {promises as fs} from 'fs';
+import {tmpdir} from 'os';
+import path from 'path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const CONFIG_ENV_KEYS = [
+  'BOT_ACTIVITY',
+  'BOT_ACTIVITY_TYPE',
+  'BOT_ACTIVITY_URL',
+  'BOT_STATUS',
+  'CACHE_LIMIT',
+  'DATA_DIR',
+  'DISCORD_TOKEN',
+  'ENABLE_SPONSORBLOCK',
+  'ENV_FILE',
+  'MUSE_BUNDLED_YT_DLP_PATH',
+  'REGISTER_COMMANDS_ON_BOT',
+  'SPONSORBLOCK_TIMEOUT',
+  'SPOTIFY_CLIENT_ID',
+  'SPOTIFY_CLIENT_SECRET',
+  'YOUTUBE_API_KEY',
+  'YT_DLP_AUTO_UPDATE',
+  'YT_DLP_PATH',
+] as const;
+
+const originalCwd = process.cwd();
+const originalEnv = {...process.env};
+let temporaryRoot: string;
+
+const resetConfigEnvironment = () => {
+  process.env = {...originalEnv};
+  for (const key of CONFIG_ENV_KEYS) {
+    delete process.env[key];
+  }
+};
+
+const loadConfig = async (environment: NodeJS.ProcessEnv = {}) => {
+  vi.resetModules();
+  resetConfigEnvironment();
+  Object.assign(process.env, environment);
+  return import('../src/services/config.js');
+};
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  resetConfigEnvironment();
+  temporaryRoot = await fs.mkdtemp(path.join(tmpdir(), 'muse-ops-startup-'));
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  process.env = {...originalEnv};
+  vi.restoreAllMocks();
+  vi.resetModules();
+  await fs.rm(temporaryRoot, {force: true, recursive: true});
+});
+
+describe('OPS-01 environment and config loading', () => {
+  it('loads cwd/.env by default and honors an explicit ENV_FILE instead', async () => {
+    const defaultEnvironmentFile = path.join(temporaryRoot, '.env');
+    const explicitEnvironmentFile = path.join(temporaryRoot, 'operator.env');
+    await fs.writeFile(defaultEnvironmentFile, [
+      'DISCORD_TOKEN=default-token',
+      'YOUTUBE_API_KEY=default-youtube-key',
+      'DATA_DIR=./default-data',
+      '',
+    ].join('\n'));
+    await fs.writeFile(explicitEnvironmentFile, [
+      'DISCORD_TOKEN=explicit-token',
+      'YOUTUBE_API_KEY=explicit-youtube-key',
+      'DATA_DIR=./explicit-data',
+      '',
+    ].join('\n'));
+    process.chdir(temporaryRoot);
+
+    const defaultModule = await loadConfig();
+    const defaultConfig = new defaultModule.default();
+    const resolvedTemporaryRoot = process.cwd();
+    expect(defaultConfig.DISCORD_TOKEN).toBe('default-token');
+    expect(defaultConfig.YOUTUBE_API_KEY).toBe('default-youtube-key');
+    expect(defaultConfig.DATA_DIR).toBe(path.join(resolvedTemporaryRoot, 'default-data'));
+
+    const explicitModule = await loadConfig({ENV_FILE: explicitEnvironmentFile});
+    const explicitConfig = new explicitModule.default();
+    expect(explicitConfig.DISCORD_TOKEN).toBe('explicit-token');
+    expect(explicitConfig.YOUTUBE_API_KEY).toBe('explicit-youtube-key');
+    expect(explicitConfig.DATA_DIR).toBe(path.join(resolvedTemporaryRoot, 'explicit-data'));
+  });
+
+  it('trims required and optional string values', async () => {
+    const {default: Config} = await loadConfig({
+      BOT_ACTIVITY: '  preservation music  ',
+      BOT_ACTIVITY_URL: '  https://example.test/activity  ',
+      BOT_STATUS: '  idle  ',
+      DISCORD_TOKEN: '  discord-secret  ',
+      SPOTIFY_CLIENT_ID: '  spotify-client  ',
+      SPOTIFY_CLIENT_SECRET: '  spotify-secret  ',
+      YOUTUBE_API_KEY: '  youtube-secret  ',
+    });
+
+    const config = new Config();
+
+    expect(config.DISCORD_TOKEN).toBe('discord-secret');
+    expect(config.YOUTUBE_API_KEY).toBe('youtube-secret');
+    expect(config.SPOTIFY_CLIENT_ID).toBe('spotify-client');
+    expect(config.SPOTIFY_CLIENT_SECRET).toBe('spotify-secret');
+    expect(config.BOT_STATUS).toBe('idle');
+    expect(config.BOT_ACTIVITY_URL).toBe('https://example.test/activity');
+    expect(config.BOT_ACTIVITY).toBe('preservation music');
+  });
+
+  it.each(['DISCORD_TOKEN', 'YOUTUBE_API_KEY'] as const)(
+    'rejects a whitespace-only %s without logging its value',
+    async requiredKey => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const exit = vi.spyOn(process, 'exit').mockImplementation(code => {
+        throw new Error(`process.exit(${String(code)})`);
+      });
+      const environment = {
+        DISCORD_TOKEN: 'discord-secret',
+        YOUTUBE_API_KEY: 'youtube-secret',
+        [requiredKey]: '   ',
+      };
+      const {default: Config} = await loadConfig(environment);
+
+      expect(() => new Config()).toThrow('process.exit(1)');
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(consoleError).toHaveBeenCalledWith(`Missing environment variable for ${requiredKey}`);
+      expect(consoleError.mock.calls.flat().join(' ')).not.toContain('discord-secret');
+      expect(consoleError.mock.calls.flat().join(' ')).not.toContain('youtube-secret');
+    },
+  );
+
+  it.each(['DISCORD_TOKEN', 'YOUTUBE_API_KEY'] as const)(
+    'rejects a missing %s without logging configured secret values',
+    async requiredKey => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const exit = vi.spyOn(process, 'exit').mockImplementation(code => {
+        throw new Error(`process.exit(${String(code)})`);
+      });
+      const environment: NodeJS.ProcessEnv = {
+        DISCORD_TOKEN: 'discord-secret',
+        YOUTUBE_API_KEY: 'youtube-secret',
+      };
+      delete environment[requiredKey];
+      const {default: Config} = await loadConfig(environment);
+
+      expect(() => new Config()).toThrow('process.exit(1)');
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(consoleError).toHaveBeenCalledWith(`Missing environment variable for ${requiredKey}`);
+      expect(consoleError.mock.calls.flat().join(' ')).not.toContain('discord-secret');
+      expect(consoleError.mock.calls.flat().join(' ')).not.toContain('youtube-secret');
+    },
+  );
+
+  it('requires literal true for booleans and accepts only finite numeric results', async () => {
+    const {default: Config} = await loadConfig({
+      DISCORD_TOKEN: 'discord-secret',
+      ENABLE_SPONSORBLOCK: 'TRUE',
+      REGISTER_COMMANDS_ON_BOT: 'true',
+      SPONSORBLOCK_TIMEOUT: '17',
+      YOUTUBE_API_KEY: 'youtube-secret',
+      YT_DLP_AUTO_UPDATE: ' true ',
+    });
+    const config = new Config();
+
+    expect(config.REGISTER_COMMANDS_ON_BOT).toBe(true);
+    expect(config.ENABLE_SPONSORBLOCK).toBe(false);
+    expect(config.YT_DLP_AUTO_UPDATE).toBe(false);
+    expect(config.SPONSORBLOCK_TIMEOUT).toBe(17);
+
+    const invalidModule = await loadConfig({
+      DISCORD_TOKEN: 'discord-secret',
+      SPONSORBLOCK_TIMEOUT: 'Infinity',
+      YOUTUBE_API_KEY: 'youtube-secret',
+    });
+    expect(() => new invalidModule.default()).toThrow('Invalid numeric value for SPONSORBLOCK_TIMEOUT');
+  });
+
+  it('uses the default data/cache paths and two-gigabyte cache limit', async () => {
+    const {default: Config, DATA_DIR} = await loadConfig({
+      DISCORD_TOKEN: 'discord-secret',
+      YOUTUBE_API_KEY: 'youtube-secret',
+    });
+    const config = new Config();
+    const expectedDataDirectory = path.resolve(originalCwd, 'data');
+
+    expect(DATA_DIR).toBe(expectedDataDirectory);
+    expect(config.DATA_DIR).toBe(expectedDataDirectory);
+    expect(config.CACHE_DIR).toBe(path.join(expectedDataDirectory, 'cache'));
+    expect(config.CACHE_LIMIT_IN_BYTES).toBe(2_000_000_000);
+  });
+
+  it.each([
+    {
+      environment: {
+        MUSE_BUNDLED_YT_DLP_PATH: '/bundled/yt-dlp',
+        YT_DLP_PATH: '  /operator/yt-dlp  ',
+      },
+      expected: '/operator/yt-dlp',
+      label: 'explicit path',
+    },
+    {
+      environment: {MUSE_BUNDLED_YT_DLP_PATH: '  /bundled/yt-dlp  '},
+      expected: '/bundled/yt-dlp',
+      label: 'bundled path',
+    },
+    {
+      environment: {},
+      expected: 'yt-dlp',
+      label: 'PATH lookup',
+    },
+  ])('selects the $label yt-dlp executable', async ({environment, expected}) => {
+    const {default: Config} = await loadConfig({
+      DISCORD_TOKEN: 'discord-secret',
+      YOUTUBE_API_KEY: 'youtube-secret',
+      ...environment,
+    });
+    const {getExecutable} = await import('../src/utils/yt-dlp.js');
+
+    expect(new Config().YT_DLP_PATH).toBe(expected);
+    expect(getExecutable()).toBe(expected);
+  });
+});
+
+interface StartHarnessOptions {
+  failAt?: string;
+}
+
+const loadStartHarness = async ({failAt}: StartHarnessOptions = {}) => {
+  vi.resetModules();
+  const events: string[] = [];
+  const dataDirectory = path.join(temporaryRoot, 'runtime-data');
+  const cacheDirectory = path.join(dataDirectory, 'cache');
+  const tmpDirectory = path.join(cacheDirectory, 'tmp');
+  const fail = (stage: string) => {
+    if (failAt === stage) {
+      throw new Error(`${stage} failed`);
+    }
+  };
+  const makeDirectory = vi.fn(async (directory: string) => {
+    const stage = directory === dataDirectory
+      ? 'mkdir:data'
+      : directory === cacheDirectory
+        ? 'mkdir:cache'
+        : 'mkdir:tmp';
+    events.push(stage);
+    fail(stage);
+    await fs.mkdir(directory, {recursive: true});
+    return directory;
+  });
+  const cleanup = vi.fn(async () => {
+    events.push('cleanup');
+    fail('cleanup');
+    await Promise.all([
+      fs.access(dataDirectory),
+      fs.access(cacheDirectory),
+      fs.access(tmpDirectory),
+    ]);
+  });
+  const prepareYtDlp = vi.fn(async () => {
+    events.push('prepare');
+    fail('prepare');
+  });
+  const register = vi.fn(async () => {
+    events.push('register');
+    fail('register');
+  });
+  const config = {
+    CACHE_DIR: cacheDirectory,
+    DATA_DIR: dataDirectory,
+  };
+  const containerGet = vi.fn((type: symbol) => {
+    switch (type.description) {
+      case 'Bot':
+        return {register};
+      case 'Config':
+        return config;
+      case 'FileCache':
+        return {cleanup};
+      default:
+        throw new Error(`Unexpected container lookup: ${String(type)}`);
+    }
+  });
+
+  vi.doMock('make-dir', () => ({default: makeDirectory}));
+  vi.doMock('../src/inversify.config.js', () => ({
+    default: {get: containerGet},
+  }));
+  vi.doMock('../src/utils/prepare-yt-dlp.js', () => ({default: prepareYtDlp}));
+
+  const {startBot} = await import('../src/index.js');
+
+  return {
+    cleanup,
+    dataDirectory,
+    events,
+    makeDirectory,
+    prepareYtDlp,
+    register,
+    startBot,
+  };
+};
+
+describe('OPS-02 startup ordering and short-circuiting', () => {
+  it('creates every runtime directory before cleanup, yt-dlp preparation, and registration', async () => {
+    const harness = await loadStartHarness();
+
+    await harness.startBot();
+
+    expect(harness.events).toEqual([
+      'mkdir:data',
+      'mkdir:cache',
+      'mkdir:tmp',
+      'cleanup',
+      'prepare',
+      'register',
+    ]);
+    await expect(fs.stat(harness.dataDirectory)).resolves.toMatchObject({});
+    expect(harness.makeDirectory).toHaveBeenCalledTimes(3);
+    expect(harness.cleanup).toHaveBeenCalledOnce();
+    expect(harness.prepareYtDlp).toHaveBeenCalledOnce();
+    expect(harness.register).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {failAt: 'mkdir:data', expected: ['mkdir:data']},
+    {failAt: 'mkdir:cache', expected: ['mkdir:data', 'mkdir:cache']},
+    {failAt: 'mkdir:tmp', expected: ['mkdir:data', 'mkdir:cache', 'mkdir:tmp']},
+    {failAt: 'cleanup', expected: ['mkdir:data', 'mkdir:cache', 'mkdir:tmp', 'cleanup']},
+    {failAt: 'prepare', expected: ['mkdir:data', 'mkdir:cache', 'mkdir:tmp', 'cleanup', 'prepare']},
+    {failAt: 'register', expected: ['mkdir:data', 'mkdir:cache', 'mkdir:tmp', 'cleanup', 'prepare', 'register']},
+  ])('stops after a rejected $failAt stage', async ({failAt, expected}) => {
+    const harness = await loadStartHarness({failAt});
+
+    await expect(harness.startBot()).rejects.toThrow(`${failAt} failed`);
+    expect(harness.events).toEqual(expected);
+  });
+});
+
+describe('OPS-04 package start routing', () => {
+  it('routes development and production starts through the database URL wrapper', async () => {
+    const packageJson = JSON.parse(
+      await fs.readFile(path.join(originalCwd, 'package.json'), 'utf8'),
+    ) as {scripts: Record<string, string>};
+
+    expect(packageJson.scripts['env:set-database-url']).toBe('tsx src/scripts/run-with-database-url.ts');
+    expect(packageJson.scripts.dev).toBe('npm run env:set-database-url -- tsx watch src/scripts/start.ts');
+    expect(packageJson.scripts.start).toBe('npm run env:set-database-url -- tsx src/scripts/migrate-and-start.ts');
+  });
+});

--- a/tests/ops-startup.test.ts
+++ b/tests/ops-startup.test.ts
@@ -36,6 +36,7 @@ const resetConfigEnvironment = () => {
 
 const loadConfig = async (environment: NodeJS.ProcessEnv = {}) => {
   vi.resetModules();
+  process.chdir(temporaryRoot);
   resetConfigEnvironment();
   Object.assign(process.env, environment);
   return import('../src/services/config.js');
@@ -72,8 +73,6 @@ describe('OPS-01 environment and config loading', () => {
       'DATA_DIR=./explicit-data',
       '',
     ].join('\n'));
-    process.chdir(temporaryRoot);
-
     const defaultModule = await loadConfig();
     const defaultConfig = new defaultModule.default();
     const resolvedTemporaryRoot = process.cwd();
@@ -184,8 +183,11 @@ describe('OPS-01 environment and config loading', () => {
       YOUTUBE_API_KEY: 'youtube-secret',
     });
     const config = new Config();
-    const expectedDataDirectory = path.resolve(originalCwd, 'data');
+    const resolvedTemporaryRoot = await fs.realpath(temporaryRoot);
+    const expectedDataDirectory = path.resolve(resolvedTemporaryRoot, 'data');
 
+    expect(process.cwd()).toBe(resolvedTemporaryRoot);
+    expect(process.cwd()).not.toBe(originalCwd);
     expect(DATA_DIR).toBe(expectedDataDirectory);
     expect(config.DATA_DIR).toBe(expectedDataDirectory);
     expect(config.CACHE_DIR).toBe(path.join(expectedDataDirectory, 'cache'));

--- a/tests/playback-attempt.test.ts
+++ b/tests/playback-attempt.test.ts
@@ -1,0 +1,77 @@
+import {describe, expect, it} from 'vitest';
+import {PlaybackAttemptTracker} from '../src/services/playback-attempt.js';
+
+type Song = {title: string};
+type Connection = {name: string};
+
+describe('PlaybackAttemptTracker', () => {
+  it('makes only the newest token latest and invalidates outstanding work', () => {
+    const tracker = new PlaybackAttemptTracker<Song, Connection>(() => ({
+      currentSong: null,
+      queueEntryVersion: null,
+      currentConnection: null,
+    }));
+
+    const first = tracker.begin();
+    const second = tracker.begin();
+
+    expect(second.id).toBeGreaterThan(first.id);
+    expect(tracker.latest()).toBe(second);
+    expect(tracker.isLatest(first)).toBe(false);
+    expect(tracker.isLatest(second)).toBe(true);
+    expect(tracker.isLatest({id: second.id})).toBe(true);
+
+    tracker.invalidate();
+
+    expect(tracker.isLatest(second)).toBe(false);
+    expect(tracker.latest().id).toBeGreaterThan(second.id);
+  });
+
+  it('requires the token and exact current connection for current ownership', () => {
+    const connection = {name: 'current'};
+    let currentConnection: Connection | null = connection;
+    const tracker = new PlaybackAttemptTracker<Song, Connection>(() => ({
+      currentSong: null,
+      queueEntryVersion: null,
+      currentConnection,
+    }));
+    const attempt = tracker.begin();
+
+    expect(tracker.isCurrent(attempt, connection)).toBe(true);
+    expect(tracker.isCurrent(attempt, {name: 'current'})).toBe(false);
+
+    currentConnection = {name: 'replacement'};
+    expect(tracker.isCurrent(attempt, connection)).toBe(false);
+  });
+
+  it('captures typed ownership and rejects song, entry, connection, and token drift', () => {
+    const firstSong = {title: 'first'};
+    const firstConnection = {name: 'first'};
+    let owner = {
+      currentSong: firstSong as Song | null,
+      queueEntryVersion: 4 as number | null,
+      currentConnection: firstConnection as Connection | null,
+    };
+    const tracker = new PlaybackAttemptTracker<Song, Connection>(() => owner);
+    const attempt = tracker.begin();
+    const context = tracker.capture(attempt, firstSong, 4, firstConnection);
+
+    expect(context).toEqual({
+      attempt,
+      song: firstSong,
+      queueEntryVersion: 4,
+      connection: firstConnection,
+    });
+    expect(tracker.owns(context)).toBe(true);
+
+    owner = {...owner, currentSong: {title: 'replacement'}};
+    expect(tracker.owns(context)).toBe(false);
+    owner = {...owner, currentSong: firstSong, queueEntryVersion: 5};
+    expect(tracker.owns(context)).toBe(false);
+    owner = {...owner, queueEntryVersion: 4, currentConnection: {name: 'replacement'}};
+    expect(tracker.owns(context)).toBe(false);
+    owner = {...owner, currentConnection: firstConnection};
+    tracker.begin();
+    expect(tracker.owns(context)).toBe(false);
+  });
+});

--- a/tests/playback-gaps.test.ts
+++ b/tests/playback-gaps.test.ts
@@ -1,0 +1,650 @@
+import 'reflect-metadata';
+import {promises as fs} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {Readable} from 'node:stream';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const dependencyMocks = vi.hoisted(() => ({
+  arrayShuffle: vi.fn((items: unknown[]) => items),
+  buildPlayingMessageEmbed: vi.fn(() => ({title: 'playing'})),
+  createAudioPlayer: vi.fn(),
+  createAudioResource: vi.fn(),
+  entersState: vi.fn(),
+  execa: vi.fn(),
+  getGuildSettings: vi.fn(),
+  getMemberVoiceChannel: vi.fn(),
+  getMostPopularVoiceChannel: vi.fn(),
+  got: vi.fn(),
+  joinVoiceChannel: vi.fn(),
+}));
+
+vi.mock('array-shuffle', () => ({
+  default: dependencyMocks.arrayShuffle,
+}));
+
+vi.mock('got', () => ({
+  default: dependencyMocks.got,
+}));
+
+vi.mock('execa', () => ({
+  execa: dependencyMocks.execa,
+}));
+
+vi.mock('@discordjs/voice', () => ({
+  AudioPlayerStatus: {Idle: 'idle'},
+  VoiceConnectionDisconnectReason: {WebSocketClose: 'websocket-close'},
+  VoiceConnectionStatus: {
+    Connecting: 'connecting',
+    Disconnected: 'disconnected',
+    Ready: 'ready',
+    Signalling: 'signalling',
+  },
+  StreamType: {WebmOpus: 'webm-opus'},
+  createAudioPlayer: dependencyMocks.createAudioPlayer,
+  createAudioResource: dependencyMocks.createAudioResource,
+  entersState: dependencyMocks.entersState,
+  joinVoiceChannel: dependencyMocks.joinVoiceChannel,
+}));
+
+vi.mock('../src/services/file-cache.js', () => ({
+  default: class {},
+}));
+
+vi.mock('../src/utils/build-embed.js', () => ({
+  buildPlayingMessageEmbed: dependencyMocks.buildPlayingMessageEmbed,
+}));
+
+vi.mock('../src/utils/get-guild-settings.js', () => ({
+  getGuildSettings: dependencyMocks.getGuildSettings,
+}));
+
+vi.mock('../src/utils/channels.js', () => ({
+  getMemberVoiceChannel: dependencyMocks.getMemberVoiceChannel,
+  getMostPopularVoiceChannel: dependencyMocks.getMostPopularVoiceChannel,
+}));
+
+import Play from '../src/commands/play.js';
+import AddQueryToQueue from '../src/services/add-query-to-queue.js';
+import Player, {MediaSource, QueuedSong, SongMetadata, STATUS} from '../src/services/player.js';
+import {getYouTubeMediaSource, YtDlpMediaUnavailableError} from '../src/utils/yt-dlp.js';
+
+const GUILD_ID = 'guild-id';
+const ORIGINAL_YT_DLP_COOKIES_PATH = process.env.YT_DLP_COOKIES_PATH;
+const ORIGINAL_YT_DLP_PATH = process.env.YT_DLP_PATH;
+const VALID_MEDIA_RESPONSE = JSON.stringify({
+  url: 'https://media.example/audio.webm',
+  http_headers: {'User-Agent': 'Muse test'},
+  is_live: false,
+});
+
+type FakeAudioPlayer = ReturnType<typeof makeAudioPlayer>;
+
+const makeAudioPlayer = () => {
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  const audioPlayer = {
+    emit: (event: string, ...args: unknown[]) => {
+      for (const handler of handlers.get(event) ?? []) {
+        handler(...args);
+      }
+    },
+    listeners: vi.fn((event: string) => handlers.get(event) ?? []),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+      return audioPlayer;
+    }),
+    pause: vi.fn(),
+    play: vi.fn(),
+    stop: vi.fn(),
+    unpause: vi.fn(),
+  };
+
+  return audioPlayer;
+};
+
+const makeVoiceConnection = () => ({
+  destroy: vi.fn(),
+  on: vi.fn(),
+  receiver: {speaking: {on: vi.fn()}},
+  rejoin: vi.fn(),
+  rejoinAttempts: 0,
+  state: {status: 'ready'},
+  subscribe: vi.fn(),
+});
+
+const makeReadyPlayer = () => {
+  const player = new Player({} as never, GUILD_ID);
+  const voiceConnection = makeVoiceConnection();
+  const getStream = vi.fn().mockResolvedValue(Readable.from([]));
+  player.voiceConnection = voiceConnection as never;
+  Object.assign(player, {getStream});
+
+  return {getStream, player, voiceConnection};
+};
+
+const getPrivatePlayer = (player: Player) => player as unknown as {
+  audioPlayer: FakeAudioPlayer | null;
+  onAudioPlayerIdle(oldState: object, newState: {status: string}): Promise<void>;
+};
+
+const makeSong = (title: string, overrides: Partial<SongMetadata> = {}): SongMetadata => ({
+  title,
+  artist: 'Artist',
+  url: title.toLowerCase().replaceAll(' ', '-'),
+  length: 100,
+  offset: 0,
+  playlist: null,
+  isLive: false,
+  thumbnailUrl: null,
+  source: MediaSource.Youtube,
+  ...overrides,
+});
+
+const makeQueuedSong = (title: string): QueuedSong => ({
+  ...makeSong(title),
+  addedInChannelId: 'text-channel-id',
+  requestedBy: 'requester-id',
+});
+
+const makeAutocompleteHarness = (query: string, spotify?: object) => {
+  const cache = {
+    wrap: vi.fn(async (operation: (...args: unknown[]) => Promise<unknown>, ...args: unknown[]) => (
+      operation(...args.slice(0, -1))
+    )),
+  };
+  const interaction = {
+    options: {getString: vi.fn(() => query)},
+    respond: vi.fn().mockResolvedValue(undefined),
+  };
+  const command = new Play(spotify ? {spotify} as never : undefined as never, cache as never, {} as never);
+
+  return {cache, command, interaction};
+};
+
+const makeQueueInteraction = () => ({
+  guild: {id: GUILD_ID},
+  member: {user: {id: 'requester-id'}},
+  channel: {id: 'text-channel-id'},
+  deferReply: vi.fn().mockResolvedValue(undefined),
+  editReply: vi.fn().mockResolvedValue(undefined),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.YT_DLP_COOKIES_PATH;
+  process.env.YT_DLP_PATH = '/fake/yt-dlp';
+  dependencyMocks.arrayShuffle.mockImplementation((items: unknown[]) => items);
+  dependencyMocks.createAudioPlayer.mockImplementation(makeAudioPlayer);
+  dependencyMocks.createAudioResource.mockImplementation((sourceStream: Readable) => ({
+    sourceStream,
+    volume: {setVolume: vi.fn()},
+  }));
+  dependencyMocks.entersState.mockResolvedValue(undefined);
+  dependencyMocks.execa.mockResolvedValue({stdout: VALID_MEDIA_RESPONSE});
+  dependencyMocks.getGuildSettings.mockResolvedValue({
+    playlistLimit: 50,
+    queueAddResponseEphemeral: false,
+    secondsToWaitAfterQueueEmpties: 0,
+  });
+  dependencyMocks.getMemberVoiceChannel.mockReturnValue([{id: 'voice-channel-id'}]);
+  dependencyMocks.getMostPopularVoiceChannel.mockReturnValue([{id: 'fallback-channel-id'}]);
+});
+
+afterEach(() => {
+  if (ORIGINAL_YT_DLP_COOKIES_PATH === undefined) {
+    delete process.env.YT_DLP_COOKIES_PATH;
+  } else {
+    process.env.YT_DLP_COOKIES_PATH = ORIGINAL_YT_DLP_COOKIES_PATH;
+  }
+
+  if (ORIGINAL_YT_DLP_PATH === undefined) {
+    delete process.env.YT_DLP_PATH;
+  } else {
+    process.env.YT_DLP_PATH = ORIGINAL_YT_DLP_PATH;
+  }
+});
+
+describe('PLAY-06 autocomplete preservation', () => {
+  it.each([
+    ['', 'blank input'],
+    ['   ', 'whitespace input'],
+    ['https://www.youtube.com/watch?v=abcdefghijk', 'HTTP URL'],
+    ['spotify:track:track-id', 'Spotify URL'],
+  ])('returns no suggestions for %s (%s)', async query => {
+    const {cache, command, interaction} = makeAutocompleteHarness(query);
+
+    await command.handleAutocompleteInteraction(interaction as never);
+
+    expect(interaction.respond).toHaveBeenCalledWith([]);
+    expect(cache.wrap).not.toHaveBeenCalled();
+    expect(dependencyMocks.got).not.toHaveBeenCalled();
+  });
+
+  it('treats unsupported custom schemes as free-text autocomplete queries', async () => {
+    const json = vi.fn().mockResolvedValue(['Queen:Bohemian Rhapsody', ['Bohemian Rhapsody Queen']]);
+    dependencyMocks.got.mockReturnValue({json});
+    const {cache, command, interaction} = makeAutocompleteHarness('  Queen:Bohemian Rhapsody  ');
+
+    await command.handleAutocompleteInteraction(interaction as never);
+
+    expect(interaction.respond).toHaveBeenCalledWith([
+      {name: 'YouTube: Bohemian Rhapsody Queen', value: 'Bohemian Rhapsody Queen'},
+    ]);
+    expect(cache.wrap).toHaveBeenCalledWith(
+      expect.any(Function),
+      'Queen:Bohemian Rhapsody',
+      undefined,
+      10,
+      {expiresIn: 3600, key: 'autocomplete:Queen:Bohemian Rhapsody'},
+    );
+  });
+
+  it('deduplicates Spotify albums before allocating slots so available tracks fill the ten-result cap', async () => {
+    dependencyMocks.got.mockReturnValue({
+      json: vi.fn().mockResolvedValue(['mix', Array.from({length: 10}, (_, index) => `YouTube ${index + 1}`)]),
+    });
+    const album = (id: string) => ({id, name: 'Duplicate Album', artists: [{name: 'Album Artist'}]});
+    const track = (index: number) => ({
+      id: `track-${index}`,
+      name: `Track ${index}`,
+      artists: [{name: `Track Artist ${index}`}],
+    });
+    const spotify = {
+      search: vi.fn().mockResolvedValue({
+        body: {
+          albums: {items: [album('album-1'), album('album-duplicate')]},
+          tracks: {items: [
+            track(1),
+            {...track(1), id: 'duplicate-track-id'},
+            track(2),
+            track(3),
+            track(4),
+          ]},
+        },
+      }),
+    };
+    const {command, interaction} = makeAutocompleteHarness('mix', spotify);
+
+    await command.handleAutocompleteInteraction(interaction as never);
+
+    const choices = interaction.respond.mock.calls[0][0] as Array<{name: string; value: string}>;
+    expect(choices).toHaveLength(10);
+    expect(choices.filter(choice => choice.value.startsWith('spotify:album:'))).toHaveLength(1);
+    expect(choices.filter(choice => choice.value.startsWith('spotify:track:'))).toHaveLength(4);
+    expect(new Set(choices.map(choice => choice.name)).size).toBe(10);
+  });
+
+  it('degrades to the capped YouTube-only result set when Spotify autocomplete fails', async () => {
+    dependencyMocks.got.mockReturnValue({
+      json: vi.fn().mockResolvedValue(['mix', Array.from({length: 12}, (_, index) => `YouTube ${index + 1}`)]),
+    });
+    const spotifyError = new Error('Spotify unavailable');
+    const spotify = {search: vi.fn().mockRejectedValue(spotifyError)};
+    const {command, interaction} = makeAutocompleteHarness('mix', spotify);
+
+    await command.handleAutocompleteInteraction(interaction as never);
+
+    const choices = interaction.respond.mock.calls[0][0] as Array<{name: string; value: string}>;
+    expect(choices).toHaveLength(10);
+    expect(choices).toEqual(Array.from({length: 10}, (_, index) => ({
+      name: `YouTube: YouTube ${index + 1}`,
+      value: `YouTube ${index + 1}`,
+    })));
+    expect(spotify.search).toHaveBeenCalledWith('mix', ['album', 'track'], {limit: 10});
+  });
+});
+
+describe('PLAY-09 shuffled additions preservation', () => {
+  it('shuffles only the resolved batch while existing history, current entry, and upcoming queue stay unchanged', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    player.add(makeQueuedSong('History'));
+    player.add(makeQueuedSong('Current'));
+    player.add(makeQueuedSong('Existing upcoming'));
+    player.manualForward(1);
+    player.voiceConnection = {} as never;
+    player.status = STATUS.PLAYING;
+    const resolvedSongs = [makeSong('New one'), makeSong('New two'), makeSong('New three')];
+    const getSongs = {getSongs: vi.fn().mockResolvedValue([resolvedSongs, ''])};
+    const playerManager = {get: vi.fn(() => player)};
+    const cache = {wrap: vi.fn()};
+    const service = new AddQueryToQueue(
+      getSongs as never,
+      playerManager as never,
+      {ENABLE_SPONSORBLOCK: false, SPONSORBLOCK_TIMEOUT: 5} as never,
+      cache as never,
+    );
+    const interaction = makeQueueInteraction();
+    dependencyMocks.arrayShuffle.mockImplementation((items: unknown[]) => [...items].reverse());
+
+    await service.addToQueue({
+      query: 'playlist',
+      addToFrontOfQueue: false,
+      shuffleAdditions: true,
+      shouldSplitChapters: false,
+      skipCurrentTrack: false,
+      interaction: interaction as never,
+    });
+
+    const state = player as unknown as {queue: QueuedSong[]; queuePosition: number};
+    expect(dependencyMocks.arrayShuffle).toHaveBeenCalledOnce();
+    expect(dependencyMocks.arrayShuffle).toHaveBeenCalledWith(resolvedSongs);
+    expect(state.queuePosition).toBe(1);
+    expect(state.queue.map(song => song.title)).toEqual([
+      'History',
+      'Current',
+      'Existing upcoming',
+      'New three',
+      'New two',
+      'New one',
+    ]);
+    expect(player.getCurrent()?.title).toBe('Current');
+    expect(player.getQueue().map(song => song.title)).toEqual([
+      'Existing upcoming',
+      'New three',
+      'New two',
+      'New one',
+    ]);
+  });
+});
+
+describe('PLAY-13 private cookie-copy preservation', () => {
+  it('runs without a cookie argument when no cookie source is configured', async () => {
+    delete process.env.YT_DLP_COOKIES_PATH;
+    process.env.YT_DLP_PATH = '/fake/yt-dlp';
+
+    await expect(getYouTubeMediaSource('abcdefghijk')).resolves.toEqual({
+      url: 'https://media.example/audio.webm',
+      headers: {'User-Agent': 'Muse test'},
+      isLive: false,
+    });
+
+    expect(dependencyMocks.execa).toHaveBeenCalledOnce();
+    const [executable, args] = dependencyMocks.execa.mock.calls[0] as [string, string[]];
+    expect(executable).toBe('/fake/yt-dlp');
+    expect(args).not.toContain('--cookies');
+    expect(args.at(-1)).toBe('https://www.youtube.com/watch?v=abcdefghijk');
+  });
+
+  it('copies configured cookies with private modes during extraction and removes the copy after success', async () => {
+    const fixtureDirectory = await fs.mkdtemp(path.join(tmpdir(), 'muse-playback-gaps-fixture-'));
+    const sourcePath = path.join(fixtureDirectory, 'mounted-cookies.txt');
+    await fs.writeFile(sourcePath, 'private-cookie-bytes', 'utf8');
+    process.env.YT_DLP_COOKIES_PATH = sourcePath;
+    process.env.YT_DLP_PATH = '/fake/yt-dlp';
+    let temporaryCookiesPath = '';
+    let temporaryDirectory = '';
+
+    dependencyMocks.execa.mockImplementation(async (_executable: string, args: string[]) => {
+      const cookiesIndex = args.indexOf('--cookies');
+      temporaryCookiesPath = args[cookiesIndex + 1];
+      temporaryDirectory = path.dirname(temporaryCookiesPath);
+      const [directoryStats, fileStats, contents] = await Promise.all([
+        fs.stat(temporaryDirectory),
+        fs.stat(temporaryCookiesPath),
+        fs.readFile(temporaryCookiesPath, 'utf8'),
+      ]);
+      expect(temporaryCookiesPath).not.toBe(sourcePath);
+      expect(directoryStats.mode & 0o777).toBe(0o700);
+      expect(fileStats.mode & 0o777).toBe(0o600);
+      expect(contents).toBe('private-cookie-bytes');
+      return {stdout: VALID_MEDIA_RESPONSE};
+    });
+
+    try {
+      await getYouTubeMediaSource('https://www.youtube.com/watch?v=abcdefghijk');
+
+      await expect(fs.access(temporaryDirectory)).rejects.toMatchObject({code: 'ENOENT'});
+      await expect(fs.readFile(sourcePath, 'utf8')).resolves.toBe('private-cookie-bytes');
+    } finally {
+      await fs.rm(fixtureDirectory, {recursive: true, force: true});
+    }
+  });
+
+  it('removes the private cookie copy when extraction fails', async () => {
+    const fixtureDirectory = await fs.mkdtemp(path.join(tmpdir(), 'muse-playback-gaps-fixture-'));
+    const sourcePath = path.join(fixtureDirectory, 'mounted-cookies.txt');
+    await fs.writeFile(sourcePath, 'private-cookie-bytes', 'utf8');
+    process.env.YT_DLP_COOKIES_PATH = sourcePath;
+    let temporaryDirectory = '';
+
+    dependencyMocks.execa.mockImplementation(async (_executable: string, args: string[]) => {
+      const cookiesIndex = args.indexOf('--cookies');
+      const temporaryCookiesPath = args[cookiesIndex + 1];
+      temporaryDirectory = path.dirname(temporaryCookiesPath);
+      await expect(fs.access(temporaryCookiesPath)).resolves.toBeUndefined();
+      throw {stderr: 'extractor process failed'};
+    });
+
+    try {
+      await expect(getYouTubeMediaSource('abcdefghijk'))
+        .rejects.toThrow('yt-dlp failed to extract media: extractor process failed');
+      await expect(fs.access(temporaryDirectory)).rejects.toMatchObject({code: 'ENOENT'});
+    } finally {
+      await fs.rm(fixtureDirectory, {recursive: true, force: true});
+    }
+  });
+});
+
+describe('PLAY-14 yt-dlp unavailable classification preservation', () => {
+  it.each([
+    ['This video is not available', 'unavailable'],
+    ['Video unavailable', 'unavailable'],
+    ['Private video', 'unavailable'],
+    ['Video has been removed', 'unavailable'],
+    ['This is members-only content', 'unavailable'],
+    ['Sign in to confirm your age', 'age-restricted'],
+  ])('classifies %s as %s', async (detail, reason) => {
+    dependencyMocks.execa.mockRejectedValue({stderr: `ERROR: ${detail}`});
+
+    await expect(getYouTubeMediaSource('abcdefghijk')).rejects.toMatchObject({
+      name: 'YtDlpMediaUnavailableError',
+      reason,
+      message: `yt-dlp failed to extract media: ERROR: ${detail}`,
+    });
+  });
+
+  it('surfaces a general extraction failure without misclassifying it as unavailable', async () => {
+    dependencyMocks.execa.mockRejectedValue({stderr: 'ERROR: upstream TLS handshake failed'});
+
+    try {
+      await getYouTubeMediaSource('abcdefghijk');
+      throw new Error('Expected extraction to fail');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(YtDlpMediaUnavailableError);
+      expect((error as Error).message).toBe('yt-dlp failed to extract media: ERROR: upstream TLS handshake failed');
+    }
+  });
+});
+
+describe('PLAY-14 unplayable queue continuation preservation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    [new YtDlpMediaUnavailableError('video unavailable', 'unavailable'), 'unavailable media'],
+    [new YtDlpMediaUnavailableError('private video', 'unavailable'), 'private media'],
+    [new YtDlpMediaUnavailableError('video has been removed', 'unavailable'), 'removed media'],
+    [new YtDlpMediaUnavailableError('sign in to confirm your age', 'age-restricted'), 'age-restricted media without a fallback'],
+    [{statusCode: 410}, 'HTTP 410 media'],
+  ])('advances exactly once past %s (%s)', async playbackError => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const {getStream, player} = makeReadyPlayer();
+    const unavailable = makeQueuedSong('Unavailable');
+    const next = makeQueuedSong('Next playable');
+    player.add(unavailable);
+    player.add(next);
+    getStream
+      .mockRejectedValueOnce(playbackError)
+      .mockResolvedValueOnce(Readable.from([]));
+    const manualForward = vi.spyOn(player, 'manualForward');
+
+    await player.play();
+
+    expect(manualForward).toHaveBeenCalledOnce();
+    expect(manualForward).toHaveBeenCalledWith(1);
+    expect(player.getCurrent()).toBe(next);
+    expect(player.getQueue()).toEqual([]);
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(getStream).toHaveBeenCalledTimes(2);
+    expect(warning).toHaveBeenCalledOnce();
+  });
+
+  it('finishes an unavailable final entry in IDLE and schedules only the configured idle timer', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    dependencyMocks.getGuildSettings.mockResolvedValue({
+      autoAnnounceNextSong: false,
+      secondsToWaitAfterQueueEmpties: 7,
+    });
+    const {getStream, player, voiceConnection} = makeReadyPlayer();
+    player.add(makeQueuedSong('Unavailable final entry'));
+    getStream.mockRejectedValueOnce(new YtDlpMediaUnavailableError('private video'));
+    const manualForward = vi.spyOn(player, 'manualForward');
+
+    await player.play();
+
+    expect(manualForward).toHaveBeenCalledOnce();
+    expect(player.getCurrent()).toBeNull();
+    expect(player.status).toBe(STATUS.IDLE);
+    expect(player.getPosition()).toBe(0);
+    expect(vi.getTimerCount()).toBe(1);
+    expect(voiceConnection.destroy).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces general playback extraction errors without advancing the queue', async () => {
+    const extractionError = new Error('ffmpeg input failed');
+    const {getStream, player} = makeReadyPlayer();
+    const current = makeQueuedSong('Current');
+    player.add(current);
+    player.add(makeQueuedSong('Must remain upcoming'));
+    getStream.mockRejectedValueOnce(extractionError);
+    const manualForward = vi.spyOn(player, 'manualForward');
+
+    await expect(player.play()).rejects.toBe(extractionError);
+
+    expect(manualForward).not.toHaveBeenCalled();
+    expect(player.getCurrent()).toBe(current);
+    expect(player.getQueue().map(song => song.title)).toEqual(['Must remain upcoming']);
+    expect(player.status).toBe(STATUS.PAUSED);
+  });
+});
+
+describe('CTRL-20 audio-idle advance preservation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('announces only the natural idle advance, not a manual forward', async () => {
+    dependencyMocks.getGuildSettings.mockResolvedValue({
+      autoAnnounceNextSong: true,
+      secondsToWaitAfterQueueEmpties: 0,
+    });
+    const {player} = makeReadyPlayer();
+    player.add(makeQueuedSong('First'));
+    player.add(makeQueuedSong('Second'));
+    player.add(makeQueuedSong('Third'));
+    const send = vi.fn().mockResolvedValue(undefined);
+    Object.assign(player, {currentChannel: {send}});
+    await player.play();
+
+    await player.forward(1);
+    expect(player.getCurrent()?.title).toBe('Second');
+    expect(send).not.toHaveBeenCalled();
+
+    await getPrivatePlayer(player).onAudioPlayerIdle(
+      {status: 'playing'},
+      {status: 'idle'},
+    );
+
+    expect(player.getCurrent()?.title).toBe('Third');
+    expect(send).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith({embeds: [{title: 'playing'}]});
+  });
+
+  it('restarts the same entry from zero when song loop is enabled', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const repeated = makeQueuedSong('Repeated');
+    player.add(repeated);
+    await player.play();
+    const entryId = player.getCurrentQueueEntryId();
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(player.getPosition()).toBe(4);
+    player.loopCurrentSong = true;
+
+    await getPrivatePlayer(player).onAudioPlayerIdle(
+      {status: 'playing'},
+      {status: 'idle'},
+    );
+
+    expect(player.getCurrent()).toBe(repeated);
+    expect(player.getCurrentQueueEntryId()).toBe(entryId);
+    expect(player.getPosition()).toBe(0);
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(getStream).toHaveBeenCalledTimes(2);
+    expect(getStream).toHaveBeenLastCalledWith(repeated, {seek: 0, to: 100});
+  });
+
+  it('re-adds each naturally completed entry so queue loop cycles in order', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const first = makeQueuedSong('First');
+    const second = makeQueuedSong('Second');
+    player.add(first);
+    player.add(second);
+    player.loopCurrentQueue = true;
+    await player.play();
+    const originalFirstEntryId = player.getCurrentQueueEntryId();
+
+    await getPrivatePlayer(player).onAudioPlayerIdle({status: 'playing'}, {status: 'idle'});
+    const secondEntryId = player.getCurrentQueueEntryId();
+    expect(player.getCurrent()).toBe(second);
+    expect(player.getQueue()).toEqual([first]);
+
+    await getPrivatePlayer(player).onAudioPlayerIdle({status: 'playing'}, {status: 'idle'});
+
+    expect(player.getCurrent()).toBe(first);
+    expect(player.getQueue()).toEqual([second]);
+    expect(player.getCurrentQueueEntryId()).not.toBe(originalFirstEntryId);
+    expect(player.getCurrentQueueEntryId()).not.toBe(secondEntryId);
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(getStream).toHaveBeenCalledTimes(3);
+  });
+
+  it('contains and logs a rejected idle handler instead of leaking an unhandled rejection', async () => {
+    const {player} = makeReadyPlayer();
+    player.add(makeQueuedSong('First'));
+    player.add(makeQueuedSong('Second'));
+    await player.play();
+    const idleError = new Error('natural advance failed');
+    vi.spyOn(player, 'forward').mockRejectedValue(idleError);
+    let resolveLogged!: (args: unknown[]) => void;
+    const logged = new Promise<unknown[]>(resolve => {
+      resolveLogged = resolve;
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      resolveLogged(args);
+    });
+    const audioPlayer = getPrivatePlayer(player).audioPlayer!;
+
+    audioPlayer.emit('idle', {status: 'playing'}, {status: 'idle'});
+
+    await expect(logged).resolves.toEqual([
+      `Audio player idle handler failed for guild ${GUILD_ID}:`,
+      idleError,
+    ]);
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/playback-gaps.test.ts
+++ b/tests/playback-gaps.test.ts
@@ -122,6 +122,34 @@ const makeReadyPlayer = () => {
   return {getStream, player, voiceConnection};
 };
 
+const makeProductionStreamPlayer = () => {
+  const fileCache = {getPathFor: vi.fn().mockResolvedValue('/cached/audio.webm')};
+  const player = new Player(fileCache as never, GUILD_ID);
+  const voiceConnection = makeVoiceConnection();
+  const createReadStream = vi.fn().mockResolvedValue(Readable.from([]));
+  player.voiceConnection = voiceConnection as never;
+  Object.assign(player, {createReadStream});
+
+  return {createReadStream, player, voiceConnection};
+};
+
+const makeDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+
+  return {promise, resolve};
+};
+
+const flushAsyncWork = async () => {
+  for (let index = 0; index < 12; index++) {
+    // Flush chained async idle-handler work without advancing timers.
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+};
+
 const getPrivatePlayer = (player: Player) => player as unknown as {
   audioPlayer: FakeAudioPlayer | null;
   onAudioPlayerIdle(oldState: object, newState: {status: string}): Promise<void>;
@@ -271,6 +299,69 @@ describe('PLAY-06 autocomplete preservation', () => {
     expect(choices).toHaveLength(10);
     expect(choices.filter(choice => choice.value.startsWith('spotify:album:'))).toHaveLength(1);
     expect(choices.filter(choice => choice.value.startsWith('spotify:track:'))).toHaveLength(4);
+    expect(new Set(choices.map(choice => choice.name)).size).toBe(10);
+  });
+
+  it('fills the Spotify half from unique albums when no tracks are available', async () => {
+    dependencyMocks.got.mockReturnValue({
+      json: vi.fn().mockResolvedValue(['albums', Array.from({length: 10}, (_, index) => `YouTube ${index + 1}`)]),
+    });
+    const albums = Array.from({length: 5}, (_, index) => ({
+      id: `album-${index + 1}`,
+      name: `Album ${index + 1}`,
+      artists: [{name: `Album Artist ${index + 1}`}],
+    }));
+    const spotify = {
+      search: vi.fn().mockResolvedValue({
+        body: {
+          albums: {items: [...albums, {...albums[0], id: 'duplicate-album-id'}]},
+          tracks: {items: []},
+        },
+      }),
+    };
+    const {command, interaction} = makeAutocompleteHarness('albums', spotify);
+
+    await command.handleAutocompleteInteraction(interaction as never);
+
+    const choices = interaction.respond.mock.calls[0][0] as Array<{name: string; value: string}>;
+    expect(choices).toHaveLength(10);
+    expect(choices.filter(choice => choice.value.startsWith('spotify:album:'))).toHaveLength(5);
+    expect(choices.filter(choice => choice.value.startsWith('spotify:track:'))).toHaveLength(0);
+    expect(choices.filter(choice => choice.name.startsWith('YouTube:'))).toHaveLength(5);
+    expect(new Set(choices.map(choice => choice.name)).size).toBe(10);
+  });
+
+  it('backfills a track-short mixed distribution with remaining unique albums', async () => {
+    dependencyMocks.got.mockReturnValue({
+      json: vi.fn().mockResolvedValue(['mixed', Array.from({length: 10}, (_, index) => `YouTube ${index + 1}`)]),
+    });
+    const albums = Array.from({length: 3}, (_, index) => ({
+      id: `album-${index + 1}`,
+      name: `Album ${index + 1}`,
+      artists: [{name: `Album Artist ${index + 1}`}],
+    }));
+    const tracks = Array.from({length: 2}, (_, index) => ({
+      id: `track-${index + 1}`,
+      name: `Track ${index + 1}`,
+      artists: [{name: `Track Artist ${index + 1}`}],
+    }));
+    const spotify = {
+      search: vi.fn().mockResolvedValue({
+        body: {
+          albums: {items: [...albums, {...albums[0], id: 'duplicate-album-id'}]},
+          tracks: {items: [...tracks, {...tracks[0], id: 'duplicate-track-id'}]},
+        },
+      }),
+    };
+    const {command, interaction} = makeAutocompleteHarness('mixed', spotify);
+
+    await command.handleAutocompleteInteraction(interaction as never);
+
+    const choices = interaction.respond.mock.calls[0][0] as Array<{name: string; value: string}>;
+    expect(choices).toHaveLength(10);
+    expect(choices.filter(choice => choice.value.startsWith('spotify:album:'))).toHaveLength(3);
+    expect(choices.filter(choice => choice.value.startsWith('spotify:track:'))).toHaveLength(2);
+    expect(choices.filter(choice => choice.name.startsWith('YouTube:'))).toHaveLength(5);
     expect(new Set(choices.map(choice => choice.name)).size).toBe(10);
   });
 
@@ -548,6 +639,92 @@ describe('CTRL-20 audio-idle advance preservation', () => {
     vi.restoreAllMocks();
   });
 
+  it('ignores Idle emitted when a manual transition programmatically stops the prior audio player', async () => {
+    dependencyMocks.getGuildSettings.mockResolvedValue({
+      autoAnnounceNextSong: true,
+      secondsToWaitAfterQueueEmpties: 0,
+    });
+    const {createReadStream, player} = makeProductionStreamPlayer();
+    player.add(makeQueuedSong('First'));
+    player.add(makeQueuedSong('Second'));
+    player.add(makeQueuedSong('Third'));
+    const send = vi.fn().mockResolvedValue(undefined);
+    Object.assign(player, {currentChannel: {send}});
+    await player.play();
+    const priorAudioPlayer = getPrivatePlayer(player).audioPlayer!;
+    priorAudioPlayer.stop.mockReturnValue(true);
+    const nextStreamStarted = makeDeferred<void>();
+    const nextStream = makeDeferred<Readable>();
+    createReadStream.mockImplementationOnce(() => {
+      nextStreamStarted.resolve(undefined);
+      return nextStream.promise;
+    });
+
+    const forward = player.forward(1);
+    await nextStreamStarted.promise;
+    priorAudioPlayer.emit('idle', {status: 'playing'}, {status: 'idle'});
+    await flushAsyncWork();
+    nextStream.resolve(Readable.from([]));
+    await forward;
+
+    expect(priorAudioPlayer.stop).toHaveBeenCalled();
+    expect(player.getCurrent()?.title).toBe('Second');
+    expect(player.getQueue().map(song => song.title)).toEqual(['Third']);
+    expect(createReadStream).toHaveBeenCalledTimes(2);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('ignores Idle synchronously emitted by a same-entry programmatic replacement', async () => {
+    dependencyMocks.getGuildSettings.mockResolvedValue({
+      autoAnnounceNextSong: true,
+      secondsToWaitAfterQueueEmpties: 0,
+    });
+    const {createReadStream, player} = makeProductionStreamPlayer();
+    const current = makeQueuedSong('Current');
+    player.add(current);
+    player.add(makeQueuedSong('Upcoming'));
+    const send = vi.fn().mockResolvedValue(undefined);
+    Object.assign(player, {currentChannel: {send}});
+    await player.play();
+    const priorAudioPlayer = getPrivatePlayer(player).audioPlayer!;
+    let emittedIdle = false;
+    priorAudioPlayer.stop.mockImplementation(() => {
+      if (!emittedIdle) {
+        emittedIdle = true;
+        priorAudioPlayer.emit('idle', {status: 'playing'}, {status: 'idle'});
+      }
+
+      return true;
+    });
+
+    await player.play();
+    await flushAsyncWork();
+
+    expect(player.getCurrent()).toBe(current);
+    expect(player.getQueue().map(song => song.title)).toEqual(['Upcoming']);
+    expect(createReadStream).toHaveBeenCalledTimes(2);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('preserves same-entry paused resume on the current audio player', async () => {
+    const {createReadStream, player} = makeProductionStreamPlayer();
+    const current = makeQueuedSong('Current');
+    player.add(current);
+    player.add(makeQueuedSong('Upcoming'));
+    await player.play();
+    const audioPlayer = getPrivatePlayer(player).audioPlayer!;
+
+    player.pause();
+    await player.play();
+
+    expect(player.getCurrent()).toBe(current);
+    expect(player.getQueue().map(song => song.title)).toEqual(['Upcoming']);
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(getPrivatePlayer(player).audioPlayer).toBe(audioPlayer);
+    expect(audioPlayer.unpause).toHaveBeenCalledOnce();
+    expect(createReadStream).toHaveBeenCalledOnce();
+  });
+
   it('announces only the natural idle advance, not a manual forward', async () => {
     dependencyMocks.getGuildSettings.mockResolvedValue({
       autoAnnounceNextSong: true,
@@ -565,10 +742,8 @@ describe('CTRL-20 audio-idle advance preservation', () => {
     expect(player.getCurrent()?.title).toBe('Second');
     expect(send).not.toHaveBeenCalled();
 
-    await getPrivatePlayer(player).onAudioPlayerIdle(
-      {status: 'playing'},
-      {status: 'idle'},
-    );
+    getPrivatePlayer(player).audioPlayer!.emit('idle', {status: 'playing'}, {status: 'idle'});
+    await flushAsyncWork();
 
     expect(player.getCurrent()?.title).toBe('Third');
     expect(send).toHaveBeenCalledOnce();

--- a/tests/player-state.test.ts
+++ b/tests/player-state.test.ts
@@ -1,0 +1,421 @@
+import {Readable} from 'node:stream';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const dependencyMocks = vi.hoisted(() => ({
+  createAudioPlayer: vi.fn(),
+  createAudioResource: vi.fn(),
+  entersState: vi.fn(),
+  getGuildSettings: vi.fn(),
+  joinVoiceChannel: vi.fn(),
+}));
+
+vi.mock('@discordjs/voice', () => ({
+  AudioPlayerStatus: {Idle: 'idle'},
+  VoiceConnectionDisconnectReason: {WebSocketClose: 'websocket-close'},
+  VoiceConnectionStatus: {
+    Connecting: 'connecting',
+    Disconnected: 'disconnected',
+    Ready: 'ready',
+    Signalling: 'signalling',
+  },
+  StreamType: {WebmOpus: 'webm-opus'},
+  createAudioPlayer: dependencyMocks.createAudioPlayer,
+  createAudioResource: dependencyMocks.createAudioResource,
+  entersState: dependencyMocks.entersState,
+  joinVoiceChannel: dependencyMocks.joinVoiceChannel,
+}));
+
+vi.mock('../src/services/file-cache.js', () => ({
+  default: class {},
+}));
+
+vi.mock('../src/utils/get-guild-settings.js', () => ({
+  getGuildSettings: dependencyMocks.getGuildSettings,
+}));
+
+vi.mock('../src/utils/build-embed.js', () => ({
+  buildPlayingMessageEmbed: vi.fn(() => ({title: 'playing'})),
+}));
+
+import Player, {MediaSource, QueuedSong, SongMetadata, STATUS} from '../src/services/player.js';
+import getProgressBar from '../src/utils/get-progress-bar.js';
+import {YtDlpMediaUnavailableError} from '../src/utils/yt-dlp.js';
+
+const GUILD_ID = 'guild-id';
+
+const makeSong = (title: string, overrides: Partial<QueuedSong> = {}): QueuedSong => ({
+  title,
+  artist: 'Artist',
+  url: title.toLowerCase().replaceAll(' ', '-'),
+  length: 100,
+  offset: 0,
+  playlist: null,
+  isLive: false,
+  thumbnailUrl: null,
+  source: MediaSource.Youtube,
+  addedInChannelId: 'text-channel-id',
+  requestedBy: 'requester-id',
+  ...overrides,
+});
+
+const makeAudioPlayer = () => ({
+  listeners: vi.fn(() => []),
+  on: vi.fn(),
+  pause: vi.fn(),
+  play: vi.fn(),
+  stop: vi.fn(),
+  unpause: vi.fn(),
+});
+
+const makeVoiceConnection = () => ({
+  destroy: vi.fn(),
+  on: vi.fn(),
+  receiver: {speaking: {on: vi.fn()}},
+  rejoin: vi.fn(),
+  rejoinAttempts: 0,
+  state: {status: 'ready'},
+  subscribe: vi.fn(),
+});
+
+const makeReadyPlayer = (ageRestrictedFallbackResolver?: (song: QueuedSong) => Promise<SongMetadata | null>) => {
+  const player = new Player({} as never, GUILD_ID, ageRestrictedFallbackResolver);
+  const voiceConnection = makeVoiceConnection();
+  const getStream = vi.fn().mockResolvedValue(Readable.from([]));
+
+  player.voiceConnection = voiceConnection as never;
+  Object.assign(player, {getStream});
+
+  return {getStream, player, voiceConnection};
+};
+
+const getPrivateState = (player: Player) => player as unknown as {
+  audioPlayer: ReturnType<typeof makeAudioPlayer> | null;
+  audioResource: {volume: {setVolume: ReturnType<typeof vi.fn>}} | null;
+  channelToSpeakingUsers: Map<string, Set<string>>;
+  currentChannel: object | undefined;
+  finishQueue(): Promise<void>;
+  playAudioPlayerResource(resource: object): void;
+};
+
+const installVoiceActivityFakes = (player: Player) => {
+  const handlers = new Map<string, (userId: string) => void>();
+  const voiceConnection = makeVoiceConnection();
+  voiceConnection.receiver.speaking.on.mockImplementation((event: string, handler: (userId: string) => void) => {
+    handlers.set(event, handler);
+  });
+  const setAudioVolume = vi.fn();
+  const members = new Map([
+    ['speaker-one', {id: 'speaker-one'}],
+    ['speaker-two', {id: 'speaker-two'}],
+  ]);
+
+  player.voiceConnection = voiceConnection as never;
+  Object.assign(player, {
+    audioPlayer: makeAudioPlayer(),
+    audioResource: {volume: {setVolume: setAudioVolume}},
+    currentChannel: {id: 'voice-channel-id', members},
+  });
+  player.registerVoiceActivityListener({
+    turnDownVolumeWhenPeopleSpeak: true,
+    turnDownVolumeWhenPeopleSpeakTarget: 20,
+  } as never);
+
+  return {handlers, members, setAudioVolume, voiceConnection};
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  dependencyMocks.createAudioPlayer.mockImplementation(makeAudioPlayer);
+  dependencyMocks.createAudioResource.mockImplementation(() => ({
+    volume: {setVolume: vi.fn()},
+  }));
+  dependencyMocks.entersState.mockResolvedValue(undefined);
+  dependencyMocks.getGuildSettings.mockResolvedValue({
+    autoAnnounceNextSong: false,
+    secondsToWaitAfterQueueEmpties: 0,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('Player forward state transitions', () => {
+  it('restores the exact original queue position when a multi-skip destination fails to play', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    player.add(makeSong('Original'));
+    player.add(makeSong('Skipped'));
+    player.add(makeSong('Failed destination'));
+    player.status = STATUS.PLAYING;
+    vi.spyOn(player, 'play').mockRejectedValue(new Error('playback failed'));
+
+    await expect(player.forward(2)).rejects.toThrow('playback failed');
+
+    expect(player.getCurrent()?.title).toBe('Original');
+    expect(player.getQueue().map(song => song.title)).toEqual(['Skipped', 'Failed destination']);
+  });
+
+  it('moves a paused non-empty queue forward while remaining paused and never schedules idle disconnect', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    const voiceConnection = makeVoiceConnection();
+    player.voiceConnection = voiceConnection as never;
+    player.add(makeSong('First'));
+    player.add(makeSong('Second'));
+    player.status = STATUS.PAUSED;
+    dependencyMocks.getGuildSettings.mockResolvedValue({secondsToWaitAfterQueueEmpties: 5});
+
+    await player.forward(1);
+
+    expect(player.getCurrent()?.title).toBe('Second');
+    expect(player.status).toBe(STATUS.PAUSED);
+    expect(dependencyMocks.getGuildSettings).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(voiceConnection.destroy).not.toHaveBeenCalled();
+  });
+
+  it('finishes a paused queue only when forwarding reaches no current entry', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    player.add(makeSong('Only entry'));
+    player.status = STATUS.PAUSED;
+
+    await player.forward(1);
+
+    expect(player.getCurrent()).toBeNull();
+    expect(player.status).toBe(STATUS.IDLE);
+    expect(dependencyMocks.getGuildSettings).toHaveBeenCalledOnce();
+  });
+});
+
+describe('Player same-URL entry identity', () => {
+  it.each([
+    ['duplicate', makeSong('Duplicate', {url: 'shared-video'})],
+    ['split chapter', makeSong('Chapter two', {url: 'shared-video', offset: 30, length: 40})],
+  ])('starts a different %s entry from zero instead of resuming the old audio resource', async (_name, nextSong) => {
+    const {getStream, player} = makeReadyPlayer();
+    const firstSong = makeSong('First entry', {url: 'shared-video', length: 30});
+    player.add(firstSong);
+    player.add(nextSong);
+
+    await player.play();
+    await vi.advanceTimersByTimeAsync(4_000);
+    player.pause();
+    const firstAudioPlayer = dependencyMocks.createAudioPlayer.mock.results[0].value as ReturnType<typeof makeAudioPlayer>;
+
+    player.manualForward(1);
+    await player.play();
+
+    expect(player.getCurrent()).toBe(nextSong);
+    expect(player.getPosition()).toBe(0);
+    expect(firstAudioPlayer.unpause).not.toHaveBeenCalled();
+    expect(dependencyMocks.createAudioPlayer).toHaveBeenCalledTimes(2);
+    expect(getStream).toHaveBeenLastCalledWith(nextSong, {
+      seek: nextSong.offset,
+      to: nextSong.offset + nextSong.length,
+    });
+  });
+
+  it('recreates a disconnected same-entry stream at its retained position', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const song = makeSong('Resume me', {url: 'same-entry'});
+    player.add(song);
+
+    await player.play();
+    await vi.advanceTimersByTimeAsync(7_000);
+    player.disconnect();
+    player.voiceConnection = makeVoiceConnection() as never;
+
+    await player.play();
+
+    expect(player.getCurrent()).toBe(song);
+    expect(player.getPosition()).toBe(7);
+    expect(getStream).toHaveBeenLastCalledWith(song, {seek: 7, to: 100});
+  });
+
+  it('treats the same song object queued twice as two different entries', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const repeatedSong = makeSong('Looped entry', {url: 'shared-object-video'});
+    player.add(repeatedSong);
+    player.add(repeatedSong);
+
+    await player.play();
+    await vi.advanceTimersByTimeAsync(4_000);
+    player.pause();
+    const firstAudioPlayer = dependencyMocks.createAudioPlayer.mock.results[0].value as ReturnType<typeof makeAudioPlayer>;
+
+    player.manualForward(1);
+    await player.play();
+
+    expect(player.getPosition()).toBe(0);
+    expect(firstAudioPlayer.unpause).not.toHaveBeenCalled();
+    expect(dependencyMocks.createAudioPlayer).toHaveBeenCalledTimes(2);
+    expect(getStream).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Player queue-finish timer state', () => {
+  it('stops the position interval before becoming idle', async () => {
+    const {player} = makeReadyPlayer();
+    player.add(makeSong('Last song'));
+    await player.play();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(player.getPosition()).toBe(3);
+
+    await getPrivateState(player).finishQueue();
+
+    expect(player.status).toBe(STATUS.IDLE);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(player.getPosition()).toBe(3);
+  });
+});
+
+describe('Player voice ducking', () => {
+  it('stores a manual session volume once across overlapping speakers and restores it after the last speaker', () => {
+    const player = new Player({} as never, GUILD_ID);
+    const {handlers, setAudioVolume} = installVoiceActivityFakes(player);
+    player.setVolume(35);
+
+    handlers.get('start')!('speaker-one');
+    handlers.get('start')!('speaker-two');
+    handlers.get('end')!('speaker-one');
+    handlers.get('end')!('speaker-two');
+
+    expect(setAudioVolume.mock.calls.map(([level]) => level)).toEqual([
+      0.35,
+      0.2,
+      0.2,
+      0.2,
+      0.35,
+    ]);
+    expect(player.getVolume()).toBe(35);
+  });
+
+  it('applies the ducking target to a new audio resource while a speaker remains active', () => {
+    const player = new Player({} as never, GUILD_ID);
+    const {handlers} = installVoiceActivityFakes(player);
+    player.setVolume(35);
+    handlers.get('start')!('speaker-one');
+    const nextResourceVolume = vi.fn();
+
+    getPrivateState(player).playAudioPlayerResource({
+      volume: {setVolume: nextResourceVolume},
+    });
+
+    expect(nextResourceVolume).toHaveBeenLastCalledWith(0.2);
+  });
+
+  it('clears ducking state on disconnect so the next session can establish and restore its own volume', () => {
+    const player = new Player({} as never, GUILD_ID);
+    const firstSession = installVoiceActivityFakes(player);
+    player.setVolume(35);
+    firstSession.handlers.get('start')!('speaker-one');
+
+    player.disconnect();
+
+    expect(player.getVolume()).toBe(35);
+    const secondSession = installVoiceActivityFakes(player);
+    player.setVolume(70);
+    expect(secondSession.setAudioVolume).toHaveBeenLastCalledWith(0.7);
+    secondSession.handlers.get('start')!('speaker-one');
+    secondSession.handlers.get('end')!('speaker-one');
+    expect(secondSession.setAudioVolume).toHaveBeenLastCalledWith(0.7);
+    expect(player.getVolume()).toBe(70);
+  });
+
+  it('ignores a late end callback from a disconnected session while the new session remains ducked', () => {
+    const player = new Player({} as never, GUILD_ID);
+    const firstSession = installVoiceActivityFakes(player);
+    player.setVolume(35);
+    firstSession.handlers.get('start')!('speaker-one');
+    player.disconnect();
+
+    const secondSession = installVoiceActivityFakes(player);
+    player.setVolume(70);
+    secondSession.handlers.get('start')!('speaker-one');
+    const secondSessionCallCount = secondSession.setAudioVolume.mock.calls.length;
+
+    firstSession.handlers.get('end')!('speaker-one');
+
+    expect(player.getVolume()).toBe(20);
+    expect(secondSession.setAudioVolume).toHaveBeenCalledTimes(secondSessionCallCount);
+  });
+
+  it('ignores a late start callback from a disconnected session after the new session becomes quiet', () => {
+    const player = new Player({} as never, GUILD_ID);
+    const firstSession = installVoiceActivityFakes(player);
+    player.setVolume(35);
+    firstSession.handlers.get('start')!('speaker-one');
+    player.disconnect();
+
+    const secondSession = installVoiceActivityFakes(player);
+    player.setVolume(70);
+    const secondSessionCallCount = secondSession.setAudioVolume.mock.calls.length;
+
+    firstSession.handlers.get('start')!('speaker-one');
+
+    expect(player.getVolume()).toBe(70);
+    expect(secondSession.setAudioVolume).toHaveBeenCalledTimes(secondSessionCallCount);
+  });
+
+  it('restores volume when a recorded speaker leaves before their end event', () => {
+    const player = new Player({} as never, GUILD_ID);
+    const {handlers, members, setAudioVolume} = installVoiceActivityFakes(player);
+    player.setVolume(35);
+    handlers.get('start')!('speaker-one');
+    members.delete('speaker-one');
+
+    handlers.get('end')!('speaker-one');
+
+    expect(setAudioVolume).toHaveBeenLastCalledWith(0.35);
+    expect(player.getVolume()).toBe(35);
+  });
+});
+
+describe('Player age-restricted fallback preservation', () => {
+  it('still replaces an age-restricted entry with its audio fallback', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fallback = makeSong('Fallback audio', {url: 'fallback-id'});
+    const resolver = vi.fn().mockResolvedValue(fallback);
+    const {getStream, player} = makeReadyPlayer(resolver);
+    const original = makeSong('Age restricted', {
+      url: 'restricted-id',
+      playlist: {title: 'Requested playlist', source: 'playlist-id'},
+    });
+    player.add(original);
+    getStream
+      .mockRejectedValueOnce(new YtDlpMediaUnavailableError('sign in to confirm your age', 'age-restricted'))
+      .mockResolvedValueOnce(Readable.from([]));
+
+    await player.play();
+
+    expect(resolver).toHaveBeenCalledWith(original);
+    expect(player.getCurrent()).toMatchObject({
+      url: 'fallback-id',
+      playlist: original.playlist,
+      addedInChannelId: original.addedInChannelId,
+      requestedBy: original.requestedBy,
+    });
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Trying audio fallback'));
+  });
+});
+
+describe('progress marker bounds', () => {
+  it.each([
+    [0, true, false],
+    [1, false, true],
+  ])('shows exactly one visible marker at progress %s', (progress, startsWithMarker, endsWithMarker) => {
+    const progressBar = getProgressBar(10, progress);
+    const characters = [...progressBar];
+
+    expect(characters).toHaveLength(10);
+    expect(characters.filter(character => character === '🔘')).toHaveLength(1);
+    expect(progressBar.startsWith('🔘')).toBe(startsWithMarker);
+    expect(progressBar.endsWith('🔘')).toBe(endsWithMarker);
+  });
+});

--- a/tests/player-state.test.ts
+++ b/tests/player-state.test.ts
@@ -192,6 +192,21 @@ describe('Player forward state transitions', () => {
 });
 
 describe('Player same-URL entry identity', () => {
+  it('exposes a distinct identity when a loop reuses the same song object as a new queue entry', () => {
+    const player = new Player({} as never, GUILD_ID);
+    const repeatedSong = makeSong('Looped entry');
+    player.add(repeatedSong);
+    const originalEntryIdentity = player.getCurrentQueueEntryId();
+
+    player.add(repeatedSong);
+    player.manualForward(1);
+
+    expect(player.getCurrent()).toBe(repeatedSong);
+    expect(originalEntryIdentity).not.toBeNull();
+    expect(typeof originalEntryIdentity).toBe('number');
+    expect(player.getCurrentQueueEntryId()).not.toBe(originalEntryIdentity);
+  });
+
   it.each([
     ['duplicate', makeSong('Duplicate', {url: 'shared-video'})],
     ['split chapter', makeSong('Chapter two', {url: 'shared-video', offset: 30, length: 40})],

--- a/tests/player-state.test.ts
+++ b/tests/player-state.test.ts
@@ -43,6 +43,24 @@ import {YtDlpMediaUnavailableError} from '../src/utils/yt-dlp.js';
 
 const GUILD_ID = 'guild-id';
 
+const makeDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return {promise, reject, resolve};
+};
+
+const makeTrackedStream = () => {
+  const stream = new Readable({read() {}});
+  const destroy = vi.spyOn(stream, 'destroy');
+
+  return {destroy, stream};
+};
+
 const makeSong = (title: string, overrides: Partial<QueuedSong> = {}): QueuedSong => ({
   title,
   artist: 'Artist',
@@ -90,10 +108,13 @@ const makeReadyPlayer = (ageRestrictedFallbackResolver?: (song: QueuedSong) => P
 
 const getPrivateState = (player: Player) => player as unknown as {
   audioPlayer: ReturnType<typeof makeAudioPlayer> | null;
-  audioResource: {volume: {setVolume: ReturnType<typeof vi.fn>}} | null;
+  audioResource: {sourceStream?: Readable; volume: {setVolume: ReturnType<typeof vi.fn>}} | null;
   channelToSpeakingUsers: Map<string, Set<string>>;
   currentChannel: object | undefined;
+  currentQueueEntryVersion: number;
   finishQueue(): Promise<void>;
+  nowPlaying: QueuedSong | null;
+  nowPlayingQueueEntryVersion: number | null;
   playAudioPlayerResource(resource: object): void;
 };
 
@@ -127,7 +148,8 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
   dependencyMocks.createAudioPlayer.mockImplementation(makeAudioPlayer);
-  dependencyMocks.createAudioResource.mockImplementation(() => ({
+  dependencyMocks.createAudioResource.mockImplementation((sourceStream: Readable) => ({
+    sourceStream,
     volume: {setVolume: vi.fn()},
   }));
   dependencyMocks.entersState.mockResolvedValue(undefined);
@@ -188,6 +210,175 @@ describe('Player forward state transitions', () => {
     expect(player.getCurrent()).toBeNull();
     expect(player.status).toBe(STATUS.IDLE);
     expect(dependencyMocks.getGuildSettings).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a newer C transition when an older B stream resolves afterward', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const first = makeSong('A');
+    const slowDestination = makeSong('B');
+    const newerDestination = makeSong('C');
+    player.add(first);
+    player.add(slowDestination);
+    player.add(newerDestination);
+    await player.play();
+
+    const slowStream = makeTrackedStream();
+    const newerStream = makeTrackedStream();
+    const slowStreamStarted = makeDeferred<void>();
+    const slowStreamResult = makeDeferred<Readable>();
+    getStream.mockReset();
+    getStream.mockImplementation((song: QueuedSong) => {
+      if (song === slowDestination) {
+        slowStreamStarted.resolve(undefined);
+        return slowStreamResult.promise;
+      }
+
+      if (song === newerDestination) {
+        return Promise.resolve(newerStream.stream);
+      }
+
+      throw new Error(`Unexpected stream request for ${song.title}`);
+    });
+
+    const olderForward = player.forward(1);
+    await slowStreamStarted.promise;
+    await player.forward(1);
+    const newerAudioPlayer = getPrivateState(player).audioPlayer;
+    const newerEntryId = player.getCurrentQueueEntryId();
+
+    slowStreamResult.resolve(slowStream.stream);
+    await olderForward;
+
+    const state = getPrivateState(player);
+    expect(player.getCurrent()).toBe(newerDestination);
+    expect(player.getCurrentQueueEntryId()).toBe(newerEntryId);
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(state.nowPlaying).toBe(newerDestination);
+    expect(state.nowPlayingQueueEntryVersion).toBe(newerEntryId);
+    expect(state.audioPlayer).toBe(newerAudioPlayer);
+    expect(state.audioResource?.sourceStream).toBe(newerStream.stream);
+    expect(slowStream.destroy).toHaveBeenCalledOnce();
+  });
+
+  it('does not roll back a newer C transition when an older B stream rejects', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const first = makeSong('A');
+    const slowDestination = makeSong('B');
+    const newerDestination = makeSong('C');
+    player.add(first);
+    player.add(slowDestination);
+    player.add(newerDestination);
+    await player.play();
+
+    const slowStreamStarted = makeDeferred<void>();
+    const slowStreamResult = makeDeferred<Readable>();
+    const newerStream = makeTrackedStream();
+    getStream.mockReset();
+    getStream.mockImplementation((song: QueuedSong) => {
+      if (song === slowDestination) {
+        slowStreamStarted.resolve(undefined);
+        return slowStreamResult.promise;
+      }
+
+      return Promise.resolve(newerStream.stream);
+    });
+
+    const olderForward = player.forward(1);
+    await slowStreamStarted.promise;
+    await player.forward(1);
+    const newerEntryId = player.getCurrentQueueEntryId();
+    const newerAudioPlayer = getPrivateState(player).audioPlayer;
+
+    slowStreamResult.reject(new Error('stale B extraction failed'));
+    await expect(olderForward).rejects.toThrow('stale B extraction failed');
+
+    const state = getPrivateState(player);
+    expect(player.getCurrent()).toBe(newerDestination);
+    expect(player.getCurrentQueueEntryId()).toBe(newerEntryId);
+    expect(state.currentQueueEntryVersion).toBe(newerEntryId);
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(state.nowPlaying).toBe(newerDestination);
+    expect(state.nowPlayingQueueEntryVersion).toBe(newerEntryId);
+    expect(state.audioPlayer).toBe(newerAudioPlayer);
+  });
+
+  it('does not run unavailable fallback or advance when an older B extraction fails after C succeeds', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const resolver = vi.fn().mockResolvedValue(null);
+    const {getStream, player} = makeReadyPlayer(resolver);
+    const first = makeSong('A');
+    const slowDestination = makeSong('B');
+    const newerDestination = makeSong('C');
+    player.add(first);
+    player.add(slowDestination);
+    player.add(newerDestination);
+    await player.play();
+
+    const slowStreamStarted = makeDeferred<void>();
+    const slowStreamResult = makeDeferred<Readable>();
+    const newerStream = makeTrackedStream();
+    getStream.mockReset();
+    getStream.mockImplementation((song: QueuedSong) => {
+      if (song === slowDestination) {
+        slowStreamStarted.resolve(undefined);
+        return slowStreamResult.promise;
+      }
+
+      return Promise.resolve(newerStream.stream);
+    });
+
+    const olderForward = player.forward(1);
+    await slowStreamStarted.promise;
+    await player.forward(1);
+    const newerEntryId = player.getCurrentQueueEntryId();
+
+    slowStreamResult.reject(new YtDlpMediaUnavailableError('sign in to confirm your age', 'age-restricted'));
+    await expect(olderForward).rejects.toBeInstanceOf(YtDlpMediaUnavailableError);
+
+    const state = getPrivateState(player);
+    expect(player.getCurrent()).toBe(newerDestination);
+    expect(player.getCurrentQueueEntryId()).toBe(newerEntryId);
+    expect(state.currentQueueEntryVersion).toBe(newerEntryId);
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(state.nowPlaying).toBe(newerDestination);
+    expect(state.nowPlayingQueueEntryVersion).toBe(newerEntryId);
+    expect(resolver).not.toHaveBeenCalled();
+    expect(getStream).toHaveBeenCalledTimes(2);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('Player playback attempt ownership', () => {
+  it('keeps the newest play attempt for the same queue entry', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const song = makeSong('Same entry');
+    const olderStream = makeTrackedStream();
+    const newerStream = makeTrackedStream();
+    const olderStreamStarted = makeDeferred<void>();
+    const olderStreamResult = makeDeferred<Readable>();
+    player.add(song);
+    getStream
+      .mockImplementationOnce(() => {
+        olderStreamStarted.resolve(undefined);
+        return olderStreamResult.promise;
+      })
+      .mockResolvedValueOnce(newerStream.stream);
+
+    const olderPlay = player.play();
+    await olderStreamStarted.promise;
+    await player.play();
+    const newerAudioPlayer = getPrivateState(player).audioPlayer;
+
+    olderStreamResult.resolve(olderStream.stream);
+    await olderPlay;
+
+    const state = getPrivateState(player);
+    expect(player.getCurrent()).toBe(song);
+    expect(state.nowPlaying).toBe(song);
+    expect(state.nowPlayingQueueEntryVersion).toBe(player.getCurrentQueueEntryId());
+    expect(state.audioPlayer).toBe(newerAudioPlayer);
+    expect(state.audioResource?.sourceStream).toBe(newerStream.stream);
+    expect(olderStream.destroy).toHaveBeenCalledOnce();
   });
 });
 
@@ -417,6 +608,80 @@ describe('Player age-restricted fallback preservation', () => {
     });
     expect(player.status).toBe(STATUS.PLAYING);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Trying audio fallback'));
+  });
+
+  it('does not apply a slow fallback to a later loop entry that reuses the same song object', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fallback = makeSong('Fallback audio', {url: 'fallback-id'});
+    const fallbackStarted = makeDeferred<void>();
+    const fallbackResult = makeDeferred<SongMetadata | null>();
+    const resolver = vi.fn().mockImplementation(() => {
+      fallbackStarted.resolve(undefined);
+      return fallbackResult.promise;
+    });
+    const {getStream, player} = makeReadyPlayer(resolver);
+    const loopedSong = makeSong('Age restricted', {url: 'restricted-id'});
+    player.add(loopedSong);
+    player.add(loopedSong);
+    const firstEntryId = player.getCurrentQueueEntryId();
+    getStream
+      .mockRejectedValueOnce(new YtDlpMediaUnavailableError('sign in to confirm your age', 'age-restricted'))
+      .mockResolvedValueOnce(Readable.from([]));
+
+    const firstEntryPlay = player.play();
+    await fallbackStarted.promise;
+    player.manualForward(1);
+    const loopedEntryId = player.getCurrentQueueEntryId();
+    expect(loopedEntryId).not.toBe(firstEntryId);
+
+    fallbackResult.resolve(fallback);
+    await firstEntryPlay;
+
+    const state = getPrivateState(player);
+    expect(player.getCurrent()).toBe(loopedSong);
+    expect(player.getCurrentQueueEntryId()).toBe(loopedEntryId);
+    expect(state.currentQueueEntryVersion).toBe(loopedEntryId);
+    expect(player.status).toBe(STATUS.PAUSED);
+    expect(state.nowPlaying).toBeNull();
+    expect(state.nowPlayingQueueEntryVersion).toBeNull();
+    expect(state.audioPlayer).toBeNull();
+    expect(getStream).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('rechecks ownership after an unusable fallback resolves before advancing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let newerForward: Promise<void> | undefined;
+    let player: Player;
+    const unusableFallback = makeSong('Unusable fallback');
+    Object.defineProperty(unusableFallback, 'source', {
+      get: () => {
+        queueMicrotask(() => {
+          newerForward = player.forward(1);
+        });
+
+        return MediaSource.HLS;
+      },
+    });
+    const resolver = vi.fn().mockResolvedValue(unusableFallback);
+    const readyPlayer = makeReadyPlayer(resolver);
+    player = readyPlayer.player;
+    const restricted = makeSong('Age restricted', {url: 'restricted-id'});
+    const newerEntry = makeSong('Newer entry');
+    player.add(restricted);
+    player.add(newerEntry);
+    readyPlayer.getStream.mockRejectedValueOnce(
+      new YtDlpMediaUnavailableError('sign in to confirm your age', 'age-restricted'),
+    );
+
+    await expect(player.play()).rejects.toBeInstanceOf(YtDlpMediaUnavailableError);
+    await newerForward;
+
+    expect(player.getCurrent()).toBe(newerEntry);
+    expect(player.status).toBe(STATUS.PAUSED);
+    expect(player.getQueue()).toEqual([]);
+    expect(readyPlayer.getStream).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/provider-routing.test.ts
+++ b/tests/provider-routing.test.ts
@@ -1,0 +1,202 @@
+import 'reflect-metadata';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const dependencyMocks = vi.hoisted(() => ({
+  ffprobe: vi.fn(),
+  shuffle: vi.fn((tracks: unknown[]) => tracks),
+}));
+
+vi.mock('fluent-ffmpeg', () => ({
+  default: vi.fn((url: string) => ({
+    ffprobe: (callback: (error: Error | null, data?: unknown) => void) => dependencyMocks.ffprobe(url, callback),
+  })),
+}));
+
+vi.mock('array-shuffle', () => ({
+  default: dependencyMocks.shuffle,
+}));
+
+vi.mock('../src/services/player.js', () => ({
+  MediaSource: {Youtube: 0, HLS: 1},
+}));
+
+import GetSongs from '../src/services/get-songs.js';
+import SpotifyAPI from '../src/services/spotify-api.js';
+
+const makeSong = (title: string, url = title.toLowerCase().replaceAll(' ', '-')) => ({
+  title,
+  artist: 'Artist',
+  url,
+  length: 180,
+  offset: 0,
+  playlist: null,
+  isLive: false,
+  thumbnailUrl: null,
+  source: 0,
+});
+
+const makeGetSongsHarness = () => {
+  const youtubeAPI = {
+    search: vi.fn().mockResolvedValue([]),
+    getVideo: vi.fn().mockResolvedValue([]),
+    getPlaylist: vi.fn().mockResolvedValue([]),
+  };
+  const spotifyAPI = {
+    getAlbum: vi.fn(),
+    getPlaylist: vi.fn(),
+    getTrack: vi.fn(),
+    getArtist: vi.fn(),
+  };
+
+  return {
+    getSongs: new GetSongs(youtubeAPI as never, spotifyAPI as never),
+    spotifyAPI,
+    youtubeAPI,
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dependencyMocks.ffprobe.mockImplementation((_url, callback) => callback(null, {}));
+  dependencyMocks.shuffle.mockImplementation((tracks: unknown[]) => tracks);
+});
+
+describe('GetSongs provider routing', () => {
+  it('uses YouTube search for a free-text query', async () => {
+    const {getSongs, youtubeAPI} = makeGetSongsHarness();
+    const result = [makeSong('Search result')];
+    youtubeAPI.search.mockResolvedValue(result);
+
+    await expect(getSongs.getSongs('lofi beats', 20, true)).resolves.toEqual([result, '']);
+    expect(youtubeAPI.search).toHaveBeenCalledWith('lofi beats', true);
+    expect(youtubeAPI.getVideo).not.toHaveBeenCalled();
+    expect(youtubeAPI.getPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('routes a YouTube URL directly to the video provider', async () => {
+    const {getSongs, youtubeAPI} = makeGetSongsHarness();
+    const result = [makeSong('YouTube result', 'abcdefghijk')];
+    const url = 'https://www.youtube.com/watch?v=abcdefghijk';
+    youtubeAPI.getVideo.mockResolvedValue(result);
+
+    await expect(getSongs.getSongs(url, 20, false)).resolves.toEqual([result, '']);
+    expect(youtubeAPI.getVideo).toHaveBeenCalledWith(url, false);
+    expect(youtubeAPI.search).not.toHaveBeenCalled();
+  });
+
+  it('routes a Spotify URL through Spotify metadata and YouTube conversion', async () => {
+    const {getSongs, spotifyAPI, youtubeAPI} = makeGetSongsHarness();
+    const result = [makeSong('Spotify result', 'spotify-result')];
+    const url = 'spotify:track:track-id';
+    spotifyAPI.getTrack.mockResolvedValue({name: 'Spotify song', artist: 'Spotify artist'});
+    youtubeAPI.search.mockResolvedValue(result);
+
+    await expect(getSongs.getSongs(url, 20, false)).resolves.toEqual([result, '']);
+    expect(spotifyAPI.getTrack).toHaveBeenCalledWith(url);
+    expect(youtubeAPI.search).toHaveBeenCalledWith('"Spotify song" "Spotify artist"', false);
+    expect(youtubeAPI.search).not.toHaveBeenCalledWith(url, false);
+  });
+
+  it('routes a direct-stream URL through ffprobe', async () => {
+    const {getSongs, youtubeAPI} = makeGetSongsHarness();
+    const url = 'https://radio.example/live.m3u8';
+
+    const [songs, extraMessage] = await getSongs.getSongs(url, 20, false);
+
+    expect(songs).toEqual([expect.objectContaining({
+      url,
+      title: url,
+      artist: url,
+      isLive: true,
+    })]);
+    expect(extraMessage).toBe('');
+    expect(dependencyMocks.ffprobe).toHaveBeenCalledWith(url, expect.any(Function));
+    expect(youtubeAPI.search).not.toHaveBeenCalled();
+  });
+
+  it('propagates a YouTube provider rejection without searching the literal URL', async () => {
+    const {getSongs, youtubeAPI} = makeGetSongsHarness();
+    const error = new Error('YouTube provider failed');
+    const url = 'https://www.youtube.com/watch?v=abcdefghijk';
+    youtubeAPI.getVideo.mockRejectedValue(error);
+    youtubeAPI.search.mockResolvedValue([makeSong('Wrong fallback')]);
+
+    await expect(getSongs.getSongs(url, 20, false)).rejects.toBe(error);
+    expect(youtubeAPI.search).not.toHaveBeenCalled();
+  });
+
+  it('propagates a Spotify provider rejection without searching the literal URL', async () => {
+    const {getSongs, spotifyAPI, youtubeAPI} = makeGetSongsHarness();
+    const error = new Error('Spotify provider failed');
+    const url = 'spotify:track:track-id';
+    spotifyAPI.getTrack.mockRejectedValue(error);
+    youtubeAPI.search.mockResolvedValue([makeSong('Wrong fallback')]);
+
+    await expect(getSongs.getSongs(url, 20, false)).rejects.toBe(error);
+    expect(youtubeAPI.search).not.toHaveBeenCalled();
+  });
+
+  it('propagates an ffprobe rejection without searching the literal URL', async () => {
+    const {getSongs, youtubeAPI} = makeGetSongsHarness();
+    const error = new Error('ffprobe failed');
+    const url = 'https://radio.example/live.m3u8';
+    dependencyMocks.ffprobe.mockImplementation((_url, callback) => callback(error));
+    youtubeAPI.search.mockResolvedValue([makeSong('Wrong fallback')]);
+
+    await expect(getSongs.getSongs(url, 20, false)).rejects.toBe(error);
+    expect(youtubeAPI.search).not.toHaveBeenCalled();
+  });
+});
+
+describe('GetSongs collection limits and conversion accounting', () => {
+  it('caps a YouTube playlist in source order', async () => {
+    const {getSongs, youtubeAPI} = makeGetSongsHarness();
+    const playlist = [makeSong('First'), makeSong('Second'), makeSong('Third')];
+    youtubeAPI.getPlaylist.mockResolvedValue(playlist);
+
+    await expect(getSongs.getSongs('https://www.youtube.com/playlist?list=PL123', 2, false))
+      .resolves.toEqual([[playlist[0], playlist[1]], '']);
+    expect(youtubeAPI.getPlaylist).toHaveBeenCalledWith('PL123', false);
+  });
+
+  it('counts a fulfilled empty Spotify conversion as one song not found', async () => {
+    const {getSongs, spotifyAPI, youtubeAPI} = makeGetSongsHarness();
+    spotifyAPI.getTrack.mockResolvedValue({name: 'Missing song', artist: 'Missing artist'});
+    youtubeAPI.search.mockResolvedValue([]);
+
+    await expect(getSongs.getSongs('spotify:track:missing-id', 20, false))
+      .resolves.toEqual([[], '1 song was not found']);
+  });
+});
+
+describe('SpotifyAPI album pagination', () => {
+  it('collects every album page before applying the configured sample limit', async () => {
+    const firstTrack = {name: 'First', artists: [{name: 'First artist'}]};
+    const secondTrack = {name: 'Second', artists: [{name: 'Second artist'}]};
+    const spotify = {
+      getAlbum: vi.fn().mockResolvedValue({
+        body: {name: 'Album', href: 'https://open.spotify.com/album/album-id'},
+      }),
+      getAlbumTracks: vi.fn()
+        .mockResolvedValueOnce({
+          body: {
+            items: [firstTrack],
+            next: 'https://api.spotify.com/v1/albums/album-id/tracks?offset=1&limit=1',
+          },
+        })
+        .mockResolvedValueOnce({
+          body: {items: [secondTrack], next: null},
+        }),
+    };
+    dependencyMocks.shuffle.mockImplementation((tracks: unknown[]) => [...tracks].reverse());
+    const spotifyAPI = new SpotifyAPI({spotify} as never);
+
+    await expect(spotifyAPI.getAlbum('spotify:album:album-id', 1)).resolves.toEqual([
+      [{name: 'Second', artist: 'Second artist'}],
+      {title: 'Album', source: 'https://open.spotify.com/album/album-id'},
+    ]);
+    expect(spotify.getAlbumTracks).toHaveBeenNthCalledWith(1, 'album-id', {limit: 50});
+    expect(spotify.getAlbumTracks).toHaveBeenNthCalledWith(2, 'album-id', {limit: 1, offset: 1});
+    expect(dependencyMocks.shuffle).toHaveBeenCalledWith([firstTrack, secondTrack]);
+  });
+});

--- a/tests/provider-routing.test.ts
+++ b/tests/provider-routing.test.ts
@@ -73,6 +73,22 @@ describe('GetSongs provider routing', () => {
     expect(youtubeAPI.getPlaylist).not.toHaveBeenCalled();
   });
 
+  it.each([
+    'Queen:Bohemian Rhapsody',
+    'C418: Sweden',
+  ])('uses YouTube search for colon-bearing free text %s', async query => {
+    const {getSongs, spotifyAPI, youtubeAPI} = makeGetSongsHarness();
+    const result = [makeSong('Search result')];
+    youtubeAPI.search.mockResolvedValue(result);
+
+    await expect(getSongs.getSongs(query, 20, true)).resolves.toEqual([result, '']);
+    expect(youtubeAPI.search).toHaveBeenCalledWith(query, true);
+    expect(youtubeAPI.getVideo).not.toHaveBeenCalled();
+    expect(youtubeAPI.getPlaylist).not.toHaveBeenCalled();
+    expect(spotifyAPI.getTrack).not.toHaveBeenCalled();
+    expect(dependencyMocks.ffprobe).not.toHaveBeenCalled();
+  });
+
   it('routes a YouTube URL directly to the video provider', async () => {
     const {getSongs, youtubeAPI} = makeGetSongsHarness();
     const result = [makeSong('YouTube result', 'abcdefghijk')];
@@ -136,10 +152,12 @@ describe('GetSongs provider routing', () => {
     expect(youtubeAPI.search).not.toHaveBeenCalled();
   });
 
-  it('propagates an ffprobe rejection without searching the literal URL', async () => {
+  it.each([
+    'http://radio.example/live.m3u8',
+    'https://radio.example/live.m3u8',
+  ])('propagates an ffprobe rejection for %s without searching the literal URL', async url => {
     const {getSongs, youtubeAPI} = makeGetSongsHarness();
     const error = new Error('ffprobe failed');
-    const url = 'https://radio.example/live.m3u8';
     dependencyMocks.ffprobe.mockImplementation((_url, callback) => callback(error));
     youtubeAPI.search.mockResolvedValue([makeSong('Wrong fallback')]);
 

--- a/tests/voice-connection-recovery.test.ts
+++ b/tests/voice-connection-recovery.test.ts
@@ -1,0 +1,180 @@
+import {
+  VoiceConnectionDisconnectReason,
+  VoiceConnectionStatus,
+  type VoiceConnection,
+} from '@discordjs/voice';
+import {describe, expect, it, vi} from 'vitest';
+import {
+  destroyVoiceConnection,
+  recoverVoiceConnection,
+  type VoiceConnectionRecoveryRuntime,
+} from '../src/services/voice-connection-recovery.js';
+
+const makeConnection = (overrides: Record<string, unknown> = {}) => ({
+  destroy: vi.fn(),
+  rejoin: vi.fn(() => true),
+  rejoinAttempts: 0,
+  state: {status: VoiceConnectionStatus.Disconnected},
+  ...overrides,
+}) as unknown as VoiceConnection;
+
+const makeHarness = (connection: VoiceConnection) => {
+  let current: VoiceConnection | null = connection;
+  const dispose = vi.fn((candidate: VoiceConnection) => {
+    destroyVoiceConnection(candidate);
+    if (current === candidate) {
+      current = null;
+    }
+  });
+  const runtime: VoiceConnectionRecoveryRuntime = {
+    waitForState: vi.fn().mockResolvedValue(undefined),
+    sleep: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    dispose,
+    getCurrent: () => current,
+    options: {
+      dispose,
+      isCurrent: (candidate: VoiceConnection) => current === candidate,
+      runtime,
+    },
+    replace: (replacement: VoiceConnection) => {
+      current = replacement;
+    },
+    runtime,
+  };
+};
+
+describe('recoverVoiceConnection', () => {
+  it.each([
+    VoiceConnectionStatus.Connecting,
+    VoiceConnectionStatus.Signalling,
+  ])('keeps a current 4014 connection recovered through %s', async recoveredStatus => {
+    const connection = makeConnection({
+      state: {
+        status: VoiceConnectionStatus.Disconnected,
+        reason: VoiceConnectionDisconnectReason.WebSocketClose,
+        closeCode: 4014,
+      },
+    });
+    const harness = makeHarness(connection);
+    harness.runtime.waitForState = vi.fn(async (_candidate, status) => {
+      if (status === recoveredStatus) {
+        connection.state = {status: recoveredStatus};
+        return;
+      }
+
+      return new Promise<never>(() => undefined);
+    });
+
+    await recoverVoiceConnection(connection, harness.options);
+
+    expect(harness.runtime.waitForState).toHaveBeenCalledWith(
+      connection,
+      VoiceConnectionStatus.Connecting,
+      5_000,
+    );
+    expect(harness.runtime.waitForState).toHaveBeenCalledWith(
+      connection,
+      VoiceConnectionStatus.Signalling,
+      5_000,
+    );
+    expect(harness.dispose).not.toHaveBeenCalled();
+    expect(harness.getCurrent()).toBe(connection);
+  });
+
+  it('disposes a 4014 timeout and never destroys an already Destroyed connection twice', async () => {
+    const connection = makeConnection({
+      state: {
+        status: VoiceConnectionStatus.Disconnected,
+        reason: VoiceConnectionDisconnectReason.WebSocketClose,
+        closeCode: 4014,
+      },
+    });
+    const harness = makeHarness(connection);
+    harness.runtime.waitForState = vi.fn().mockImplementation(async () => {
+      connection.state = {status: VoiceConnectionStatus.Destroyed};
+      throw new Error('timeout');
+    });
+
+    await recoverVoiceConnection(connection, harness.options);
+
+    expect(harness.dispose).toHaveBeenCalledOnce();
+    expect(connection.destroy).not.toHaveBeenCalled();
+    expect(harness.getCurrent()).toBeNull();
+  });
+
+  it('backs off in five-second increments and accepts a successful rejoin below five attempts', async () => {
+    const connection = makeConnection({rejoinAttempts: 2});
+    const harness = makeHarness(connection);
+
+    await recoverVoiceConnection(connection, harness.options);
+
+    expect(harness.runtime.sleep).toHaveBeenCalledWith(15_000);
+    expect(connection.rejoin).toHaveBeenCalledOnce();
+    expect(harness.dispose).not.toHaveBeenCalled();
+  });
+
+  it('preserves a connection that becomes Ready during transient backoff', async () => {
+    const connection = makeConnection({rejoinAttempts: 1});
+    const harness = makeHarness(connection);
+    harness.runtime.sleep = vi.fn(async () => {
+      connection.state = {status: VoiceConnectionStatus.Ready};
+    });
+
+    await recoverVoiceConnection(connection, harness.options);
+
+    expect(connection.rejoin).not.toHaveBeenCalled();
+    expect(harness.dispose).not.toHaveBeenCalled();
+    expect(harness.getCurrent()).toBe(connection);
+  });
+
+  it('disposes a stale owner after backoff without touching its replacement', async () => {
+    const connection = makeConnection({rejoinAttempts: 1});
+    const replacement = makeConnection();
+    const harness = makeHarness(connection);
+    harness.runtime.sleep = vi.fn(async () => {
+      harness.replace(replacement);
+    });
+
+    await recoverVoiceConnection(connection, harness.options);
+
+    expect(connection.rejoin).not.toHaveBeenCalled();
+    expect(connection.destroy).toHaveBeenCalledOnce();
+    expect(replacement.destroy).not.toHaveBeenCalled();
+    expect(harness.getCurrent()).toBe(replacement);
+  });
+
+  it.each([
+    {name: 'failed rejoin', attempts: 0, rejoin: false, sleeps: true},
+    {name: 'exhausted retries', attempts: 5, rejoin: true, sleeps: false},
+  ])('disposes a disconnected connection after $name', async ({attempts, rejoin, sleeps}) => {
+    const connection = makeConnection({
+      rejoin: vi.fn(() => rejoin),
+      rejoinAttempts: attempts,
+    });
+    const harness = makeHarness(connection);
+
+    await recoverVoiceConnection(connection, harness.options);
+
+    expect(harness.runtime.sleep).toHaveBeenCalledTimes(sleeps ? 1 : 0);
+    expect(connection.rejoin).toHaveBeenCalledTimes(attempts < 5 ? 1 : 0);
+    expect(harness.dispose).toHaveBeenCalledOnce();
+    expect(connection.destroy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('destroyVoiceConnection', () => {
+  it('is idempotent for a connection whose destroy transitions its state', () => {
+    const connection = makeConnection();
+    vi.mocked(connection.destroy).mockImplementation(() => {
+      connection.state = {status: VoiceConnectionStatus.Destroyed};
+    });
+
+    destroyVoiceConnection(connection);
+    destroyVoiceConnection(connection);
+
+    expect(connection.destroy).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/youtube-api.test.ts
+++ b/tests/youtube-api.test.ts
@@ -191,6 +191,21 @@ describe('YoutubeAPI chapter parsing', () => {
     await expect(api.getVideo(video.id, true)).resolves.toHaveLength(2);
   });
 
+  it.each(['0:00:00', '00:00:00'])('accepts an all-zero hour-form %s first chapter timestamp', async start => {
+    const video = makeVideo({
+      id: 'hours000001',
+      duration: 'PT2M',
+      title: 'Hour-form chapters',
+      description: `${start} Intro\n0:01:00 Main`,
+    });
+    const {api} = makeHarness({videos: [video]});
+
+    expect(chapterSummary(await api.getVideo(video.id, true))).toEqual([
+      {title: 'Intro (Hour-form chapters)', offset: 0, length: 60},
+      {title: 'Main (Hour-form chapters)', offset: 60, length: 60},
+    ]);
+  });
+
   it('does not treat 10:00 as a zero-start timestamp by substring', async () => {
     const video = makeVideo({
       id: 'notzero0001',

--- a/tests/youtube-api.test.ts
+++ b/tests/youtube-api.test.ts
@@ -224,21 +224,18 @@ describe('YoutubeAPI chapter parsing', () => {
     ]);
   });
 
-  it('does not scan past an earlier timestamp to find a later zero start', async () => {
+  it('scans past an incidental earlier timestamp to find a later zero-start chapter block', async () => {
     const video = makeVideo({
       id: 'laterzero01',
       duration: 'PT3M',
-      title: 'Unsplit video',
+      title: 'Chaptered video',
       description: '10:00 Preface\n0:00 Intro\n1:00 Main',
     });
     const {api} = makeHarness({videos: [video]});
 
-    await expect(api.getVideo(video.id, true)).resolves.toEqual([
-      expect.objectContaining({
-        title: video.snippet.title,
-        offset: 0,
-        length: 180,
-      }),
+    expect(chapterSummary(await api.getVideo(video.id, true))).toEqual([
+      {title: 'Intro (Chaptered video)', offset: 0, length: 60},
+      {title: 'Main (Chaptered video)', offset: 60, length: 120},
     ]);
   });
 

--- a/tests/youtube-api.test.ts
+++ b/tests/youtube-api.test.ts
@@ -1,0 +1,290 @@
+import 'reflect-metadata';
+import {describe, expect, it, vi} from 'vitest';
+
+vi.mock('../src/services/player.js', () => ({
+  MediaSource: {Youtube: 0},
+}));
+
+import YoutubeAPI from '../src/services/youtube-api.js';
+
+interface PlaylistItemPage {
+  items: Array<{
+    id: string;
+    contentDetails: {videoId: string};
+  }>;
+  nextPageToken?: string;
+}
+
+const PLAYLIST_ID = 'playlist-id';
+
+const makeVideo = ({
+  id,
+  description = '',
+  duration = 'PT3M',
+  title = id,
+}: {
+  id: string;
+  description?: string;
+  duration?: string;
+  title?: string;
+}) => ({
+  id,
+  contentDetails: {
+    videoId: id,
+    duration,
+  },
+  snippet: {
+    title,
+    channelTitle: 'Channel',
+    liveBroadcastContent: 'none',
+    description,
+    thumbnails: {
+      medium: {url: `https://example.com/${id}.jpg`},
+    },
+  },
+});
+
+const makePlaylistItem = (videoId: string) => ({
+  id: `playlist-item-${videoId}`,
+  contentDetails: {videoId},
+});
+
+const makeHarness = ({
+  itemCount = 0,
+  pages = [],
+  videos = [],
+}: {
+  itemCount?: number;
+  pages?: PlaylistItemPage[];
+  videos?: ReturnType<typeof makeVideo>[];
+} = {}) => {
+  const remainingPages = [...pages];
+  const videoById = new Map(videos.map(video => [video.id, video]));
+  let playlistItemsCallCount = 0;
+
+  const cache = {
+    wrap: vi.fn(async (
+      _fetchValue: () => Promise<unknown>,
+      {searchParams}: {searchParams: Record<string, string | undefined>},
+    ) => {
+      if (searchParams.playlistId === PLAYLIST_ID) {
+        playlistItemsCallCount++;
+        const page = remainingPages.shift();
+        if (!page) {
+          throw new Error('playlistItems page was requested again');
+        }
+
+        return page;
+      }
+
+      if (searchParams.id === PLAYLIST_ID) {
+        return {
+          items: [{
+            id: PLAYLIST_ID,
+            contentDetails: {itemCount},
+            snippet: {title: 'Playlist'},
+          }],
+        };
+      }
+
+      const requestedVideoIds = searchParams.id?.split(',').filter(Boolean) ?? [];
+      return {
+        items: requestedVideoIds
+          .map(id => videoById.get(id))
+          .filter((video): video is ReturnType<typeof makeVideo> => Boolean(video)),
+      };
+    }),
+  };
+
+  return {
+    api: new YoutubeAPI({YOUTUBE_API_KEY: 'test-key'} as never, cache as never),
+    cache,
+    getPlaylistItemsCallCount: () => playlistItemsCallCount,
+  };
+};
+
+const chapterSummary = (songs: Awaited<ReturnType<YoutubeAPI['getVideo']>>) => songs.map(song => ({
+  title: song.title,
+  offset: song.offset,
+  length: song.length,
+}));
+
+describe('YoutubeAPI playlist pagination', () => {
+  it('retains all fetched details across pages and stops when the final page has no token', async () => {
+    const firstVideo = makeVideo({id: 'video-first', title: 'First'});
+    const secondVideo = makeVideo({id: 'video-second', title: 'Second'});
+    const {api, getPlaylistItemsCallCount} = makeHarness({
+      itemCount: 99,
+      pages: [
+        {items: [makePlaylistItem(firstVideo.id)], nextPageToken: 'page-2'},
+        {items: [makePlaylistItem(secondVideo.id)]},
+      ],
+      videos: [firstVideo, secondVideo],
+    });
+
+    const songs = await api.getPlaylist(PLAYLIST_ID, false);
+
+    expect(songs.map(song => ({title: song.title, url: song.url}))).toEqual([
+      {title: 'First', url: firstVideo.id},
+      {title: 'Second', url: secondVideo.id},
+    ]);
+    expect(songs.every(song => song.playlist?.source === PLAYLIST_ID)).toBe(true);
+    expect(getPlaylistItemsCallCount()).toBe(2);
+  });
+
+  it('stops before requesting a repeated page token and retains every processed page', async () => {
+    const firstVideo = makeVideo({id: 'video-first', title: 'First'});
+    const secondVideo = makeVideo({id: 'video-second', title: 'Second'});
+    const {api, getPlaylistItemsCallCount} = makeHarness({
+      itemCount: 99,
+      pages: [
+        {items: [makePlaylistItem(firstVideo.id)], nextPageToken: 'page-2'},
+        {items: [makePlaylistItem(secondVideo.id)], nextPageToken: 'page-2'},
+      ],
+      videos: [firstVideo, secondVideo],
+    });
+
+    const songs = await api.getPlaylist(PLAYLIST_ID, false);
+
+    expect(songs.map(song => ({title: song.title, url: song.url}))).toEqual([
+      {title: 'First', url: firstVideo.id},
+      {title: 'Second', url: secondVideo.id},
+    ]);
+    expect(getPlaylistItemsCallCount()).toBe(2);
+  });
+
+  it('terminates after a truncated page without a token even when itemCount is stale', async () => {
+    const onlyVideo = makeVideo({id: 'only-video', title: 'Only'});
+    const {api, getPlaylistItemsCallCount} = makeHarness({
+      itemCount: 50,
+      pages: [{items: [makePlaylistItem(onlyVideo.id)]}],
+      videos: [onlyVideo],
+    });
+
+    await expect(api.getPlaylist(PLAYLIST_ID, false)).resolves.toEqual([
+      expect.objectContaining({title: 'Only', url: onlyVideo.id}),
+    ]);
+    expect(getPlaylistItemsCallCount()).toBe(1);
+  });
+
+  it('returns an empty playlist after one empty page without repeating the request', async () => {
+    const {api, getPlaylistItemsCallCount} = makeHarness({
+      itemCount: 1,
+      pages: [{items: []}],
+    });
+
+    await expect(api.getPlaylist(PLAYLIST_ID, false)).resolves.toEqual([]);
+    expect(getPlaylistItemsCallCount()).toBe(1);
+  });
+});
+
+describe('YoutubeAPI chapter parsing', () => {
+  it.each(['0:00', '00:00'])('accepts an exact %s first chapter timestamp', async start => {
+    const video = makeVideo({
+      id: 'chaptered01',
+      duration: 'PT2M',
+      title: 'Chaptered video',
+      description: `${start} Intro\n1:00 Main`,
+    });
+    const {api} = makeHarness({videos: [video]});
+
+    await expect(api.getVideo(video.id, true)).resolves.toHaveLength(2);
+  });
+
+  it('does not treat 10:00 as a zero-start timestamp by substring', async () => {
+    const video = makeVideo({
+      id: 'notzero0001',
+      duration: 'PT20M',
+      title: 'Unsplit video',
+      description: '10:00 First mention\n11:00 Second mention',
+    });
+    const {api} = makeHarness({videos: [video]});
+
+    await expect(api.getVideo(video.id, true)).resolves.toEqual([
+      expect.objectContaining({
+        title: video.snippet.title,
+        offset: 0,
+        length: 1200,
+      }),
+    ]);
+  });
+
+  it('does not scan past an earlier timestamp to find a later zero start', async () => {
+    const video = makeVideo({
+      id: 'laterzero01',
+      duration: 'PT3M',
+      title: 'Unsplit video',
+      description: '10:00 Preface\n0:00 Intro\n1:00 Main',
+    });
+    const {api} = makeHarness({videos: [video]});
+
+    await expect(api.getVideo(video.id, true)).resolves.toEqual([
+      expect.objectContaining({
+        title: video.snippet.title,
+        offset: 0,
+        length: 180,
+      }),
+    ]);
+  });
+
+  it.each([
+    ['descending offsets', '0:00 Intro\n1:30 Middle\n1:00 Backwards'],
+    ['repeated offsets', '0:00 Intro\n1:00 Middle\n1:00 Duplicate'],
+    ['an offset at the video duration', '0:00 Intro\n2:00 At end'],
+    ['an offset outside the video duration', '0:00 Intro\n2:01 Too late'],
+    ['an empty label', '0:00\n1:00 Main'],
+  ])('falls back to the unsplit video for %s', async (_caseName, description) => {
+    const video = makeVideo({
+      id: 'invalid0001',
+      duration: 'PT2M',
+      title: 'Unsplit video',
+      description,
+    });
+    const {api} = makeHarness({videos: [video]});
+
+    await expect(api.getVideo(video.id, true)).resolves.toEqual([
+      expect.objectContaining({
+        title: video.snippet.title,
+        offset: 0,
+        length: 120,
+      }),
+    ]);
+  });
+
+  it('calculates every valid chapter length from the next offset and video duration', async () => {
+    const video = makeVideo({
+      id: 'valid000001',
+      duration: 'PT2M',
+      title: 'Chaptered video',
+      description: '00:00 Intro\n0:45 Verse\n1:30 Outro',
+    });
+    const {api} = makeHarness({videos: [video]});
+
+    await expect(api.getVideo(video.id, true)).resolves.toSatisfy(songs => {
+      expect(chapterSummary(songs)).toEqual([
+        {title: 'Intro (Chaptered video)', offset: 0, length: 45},
+        {title: 'Verse (Chaptered video)', offset: 45, length: 45},
+        {title: 'Outro (Chaptered video)', offset: 90, length: 30},
+      ]);
+      return true;
+    });
+  });
+
+  it('preserves valid chapters that have duplicate non-empty labels', async () => {
+    const video = makeVideo({
+      id: 'duplicate01',
+      duration: 'PT2M',
+      title: 'Chaptered video',
+      description: '0:00 Part\n0:30 Part\n1:00 Finale',
+    });
+    const {api} = makeHarness({videos: [video]});
+
+    const songs = await api.getVideo(video.id, true);
+
+    expect(chapterSummary(songs)).toEqual([
+      {title: 'Part (Chaptered video)', offset: 0, length: 30},
+      {title: 'Part (Chaptered video)', offset: 30, length: 30},
+      {title: 'Finale (Chaptered video)', offset: 60, length: 60},
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,6 +185,28 @@
   dependencies:
     undici "^6.18.2"
 
+"@emnapi/core@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.11.1.tgz#b9e1064f3a6b1631e241e638eb48d736bfd372a6"
+  integrity sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.2"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.1.tgz#58f1f3d5d81a9b12f793ab688c96371901027c24"
+  integrity sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz#4c93becf5bfa3b13d1bbdcc06aee38321ad8139a"
+  integrity sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==
+  dependencies:
+    tslib "^2.4.0"
+
 "@esbuild-kit/cjs-loader@^2.3.3":
   version "2.4.4"
   resolved "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.4.tgz#8638177732e2de258a3243597bfdba082993c442"
@@ -394,12 +416,24 @@
   resolved "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.4.tgz#c65172283db9516c4a27e8d673ca7a31a07d528b"
   integrity sha512-u95rV3lKfG+NT2Uy/5vNzoDujos8vN8O18SSA5UyhxsGYd4GLQn/eUsGXfOsfa7m34eKrDelTKRUX1m/BcNX5w==
 
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
 "@napi-rs/wasm-runtime@^1.1.2":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz#a46bbfedc29751b7170c5d23bc1d8ee8c7e3c1e1"
   integrity sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==
   dependencies:
     "@tybys/wasm-util" "^0.10.1"
+
+"@napi-rs/wasm-runtime@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
+  integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.3"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -523,6 +557,11 @@
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
 
+"@oxc-project/types@=0.139.0":
+  version "0.139.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.139.0.tgz#38d76b9dbf934c2a02be174fb32ceebf182fe742"
+  integrity sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==
+
 "@prisma/client@4.16.0":
   version "4.16.0"
   resolved "https://registry.npmjs.org/@prisma/client/-/client-4.16.0.tgz#1526414d69bb0db5efff0c8b0b99db65b11c6da4"
@@ -578,6 +617,90 @@
   dependencies:
     detect-newline "^3.1.0"
     string-template "^1.0.0"
+
+"@rolldown/binding-android-arm64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz#f58cb9a0a8128ed0582282720528547fc5c035f3"
+  integrity sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==
+
+"@rolldown/binding-darwin-arm64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz#441144c05a4a831aa75269abc3a4a324374ea707"
+  integrity sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==
+
+"@rolldown/binding-darwin-x64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz#c82e30652cef52c4af925d5c66c8955a40319816"
+  integrity sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==
+
+"@rolldown/binding-freebsd-x64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz#c32e9ce7fa1c0fb2b80913a2a3a05c3e907d06b0"
+  integrity sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz#ce90b5e22316adeb502ea010582f498cd0604f27"
+  integrity sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==
+
+"@rolldown/binding-linux-arm64-gnu@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz#91947110c4ddaa4eefb004e52688070977085201"
+  integrity sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==
+
+"@rolldown/binding-linux-arm64-musl@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz#eb32b2d4108c1c702b91e8cde8a043eae5caa94d"
+  integrity sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==
+
+"@rolldown/binding-linux-ppc64-gnu@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz#ccb943c11e5a72655cbb02fc1163541ceb640782"
+  integrity sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==
+
+"@rolldown/binding-linux-s390x-gnu@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz#a33731ee567e90b75fac6e5e55307e8a2b3038f0"
+  integrity sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==
+
+"@rolldown/binding-linux-x64-gnu@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz#a74c01aaacedfc11c39b6feba33a5fa0c654949f"
+  integrity sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==
+
+"@rolldown/binding-linux-x64-musl@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz#28cd178494fa1e65dba412229b5ce55c4dd5cbd1"
+  integrity sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==
+
+"@rolldown/binding-openharmony-arm64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz#f7c75fa913fc20884d26a7d488d4f5c597cd71c0"
+  integrity sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==
+
+"@rolldown/binding-wasm32-wasi@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz#c379581947787081df363ea106140fcd5fec252d"
+  integrity sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==
+  dependencies:
+    "@emnapi/core" "1.11.1"
+    "@emnapi/runtime" "1.11.1"
+    "@napi-rs/wasm-runtime" "^1.1.6"
+
+"@rolldown/binding-win32-arm64-msvc@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz#f23c88694f7a729a12f395024aee38df80a16ba3"
+  integrity sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==
+
+"@rolldown/binding-win32-x64-msvc@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz#3377c8de0e56a8857f11217561147090e874cb46"
+  integrity sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==
+
+"@rolldown/pluginutils@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
 
 "@sapphire/async-queue@^1.3.2", "@sapphire/async-queue@^1.5.0":
   version "1.5.5"
@@ -707,6 +830,11 @@
     "@snazzah/davey-win32-ia32-msvc" "0.1.11"
     "@snazzah/davey-win32-x64-msvc" "0.1.11"
 
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -738,10 +866,25 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@types/bluebird@^3.5.35":
   version "3.5.42"
   resolved "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz#7ec05f1ce9986d920313c1377a5662b1b563d366"
   integrity sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==
+
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
 
 "@types/debug@^4.1.5":
   version "4.1.12"
@@ -749,6 +892,16 @@
   integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
   dependencies:
     "@types/ms" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
+
+"@types/estree@^1.0.0":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/fluent-ffmpeg@^2.1.17":
   version "2.1.27"
@@ -919,6 +1072,66 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@vitest/expect@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.10.tgz#799c06fc44bb0cf7e2784137b627c5cc173285d4"
+  integrity sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
+
+"@vitest/mocker@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.10.tgz#2413987ab4cd7fa1c2b614b404c407bf6ad1ead1"
+  integrity sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==
+  dependencies:
+    "@vitest/spy" "4.1.10"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.10.tgz#75542e7273a08cc10fd4d8dad4e3eb1f16cd958c"
+  integrity sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==
+  dependencies:
+    tinyrainbow "^3.1.0"
+
+"@vitest/runner@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.10.tgz#febf0a21a9168421422d1955370e606feab60355"
+  integrity sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==
+  dependencies:
+    "@vitest/utils" "4.1.10"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.10.tgz#7e3e9fec7d4d47232e493cfdcbd2170de4371c04"
+  integrity sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==
+  dependencies:
+    "@vitest/pretty-format" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.10.tgz#5c0bfa97b56bba9e37403c976db776ff6ab56f65"
+  integrity sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==
+
+"@vitest/utils@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.10.tgz#ffc71055f18bfccb1fd0586365ebc2824892e403"
+  integrity sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==
+  dependencies:
+    "@vitest/pretty-format" "4.1.10"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
 
 "@vladfrangu/async_event_emitter@^2.2.1":
   version "2.4.7"
@@ -1153,6 +1366,11 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 ast-types@^0.13.2:
   version "0.13.4"
   resolved "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
@@ -1354,6 +1572,11 @@ camelcase@^6.2.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
+
 chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1509,6 +1732,11 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
+
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 cookiejar@^2.1.2:
   version "2.1.4"
@@ -1712,6 +1940,11 @@ detect-libc@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700"
   integrity sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==
+
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-newline@^3.1.0:
   version "3.1.0"
@@ -1928,6 +2161,11 @@ es-get-iterator@^1.0.2:
     is-string "^1.0.7"
     isarray "^2.0.5"
     stop-iteration-iterator "^1.0.0"
+
+es-module-lexer@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.3.0.tgz#fda770234c345064c122eb905e1c4200ffa4ce7e"
+  integrity sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
@@ -2314,6 +2552,13 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -2379,6 +2624,11 @@ execa@^6.1.0:
     signal-exit "^3.0.7"
     strip-final-newline "^3.0.0"
 
+expect-type@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
+
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -2430,6 +2680,11 @@ fastq@^1.6.0:
   integrity sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==
   dependencies:
     reusify "^1.0.4"
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 figures@^3.0.0:
   version "3.2.0"
@@ -2611,7 +2866,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@2.3.3, fsevents@~2.3.2:
+fsevents@2.3.3, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -3650,6 +3905,80 @@ libsodium@^0.7.15:
   resolved "https://registry.npmjs.org/libsodium/-/libsodium-0.7.15.tgz#ac284e3dcb1c29ae9526c5581cdada6a072f6d20"
   integrity sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw==
 
+lightningcss-android-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz#f033885116dfefd9c6f54787523e3514b61e1968"
+  integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
+
+lightningcss-darwin-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz#50b71871b01c8199584b649e292547faea7af9b5"
+  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
+
+lightningcss-darwin-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz#35f3e97332d130b9ca181e11b568ded6aebc6d5e"
+  integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
+
+lightningcss-freebsd-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz#9777a76472b64ed6ff94342ad64c7bafd794a575"
+  integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
+
+lightningcss-linux-arm-gnueabihf@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz#13ae652e1ab73b9135d7b7da172f666c410ad53d"
+  integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
+
+lightningcss-linux-arm64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz#417858795a94592f680123a1b1f9da8a0e1ef335"
+  integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
+
+lightningcss-linux-arm64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz#6be36692e810b718040802fd809623cffe732133"
+  integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
+
+lightningcss-linux-x64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz#0b7803af4eb21cfd38dd39fe2abbb53c7dd091f6"
+  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
+
+lightningcss-linux-x64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz#88dc8ba865ddddb1ac5ef04b0f161804418c163b"
+  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
+
+lightningcss-win32-arm64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz#4f30ba3fa5e925f5b79f945e8cc0d176c3b1ab38"
+  integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
+
+lightningcss-win32-x64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz#141aa5605645064928902bb4af045fa7d9f4220a"
+  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
+
+lightningcss@^1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.32.0.tgz#b85aae96486dcb1bf49a7c8571221273f4f1e4a9"
+  integrity sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.32.0"
+    lightningcss-darwin-arm64 "1.32.0"
+    lightningcss-darwin-x64 "1.32.0"
+    lightningcss-freebsd-x64 "1.32.0"
+    lightningcss-linux-arm-gnueabihf "1.32.0"
+    lightningcss-linux-arm64-gnu "1.32.0"
+    lightningcss-linux-arm64-musl "1.32.0"
+    lightningcss-linux-x64-gnu "1.32.0"
+    lightningcss-linux-x64-musl "1.32.0"
+    lightningcss-win32-arm64-msvc "1.32.0"
+    lightningcss-win32-x64-msvc "1.32.0"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -3739,6 +4068,13 @@ macos-release@^2.5.0:
   version "2.5.1"
   resolved "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz#bccac4a8f7b93163a8d163b8ebf385b3c5f55bf9"
   integrity sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A==
+
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 make-dir@^3.0.0, make-dir@^3.1.0:
   version "3.1.0"
@@ -3878,6 +4214,11 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nanoid@^3.3.12:
+  version "3.3.15"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.15.tgz#36c490fad8c6e86c824c940dfdde999b69ed4316"
+  integrity sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4033,6 +4374,11 @@ object.values@^1.1.7:
     call-bound "^1.0.3"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
+
+obug@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.3.tgz#c02c60f95abd603409330e767db7f2823193331e"
+  integrity sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -4348,12 +4694,17 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 peek-readable@^5.1.3:
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-5.4.2.tgz#aff1e1ba27a7d6911ddb103f35252ffc1787af49"
   integrity sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==
 
-picocolors@^1.0.0:
+picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -4362,6 +4713,11 @@ picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.3, picomatch@^4.0.4, picomatch@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 pkg-dir@^5.0.0:
   version "5.0.0"
@@ -4381,6 +4737,15 @@ possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
+
+postcss@^8.5.16:
+  version "8.5.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.17.tgz#45f1f5fd542e2bc18ba8bbf92c85c3cd8485c285"
+  integrity sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==
+  dependencies:
+    nanoid "^3.3.12"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 postinstall-postinstall@^2.1.0:
   version "2.1.0"
@@ -4763,6 +5128,30 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rolldown@~1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.1.5.tgz#339aae250844351fc55b74e2652d3ebd6fba389d"
+  integrity sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==
+  dependencies:
+    "@oxc-project/types" "=0.139.0"
+    "@rolldown/pluginutils" "^1.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.1.5"
+    "@rolldown/binding-darwin-arm64" "1.1.5"
+    "@rolldown/binding-darwin-x64" "1.1.5"
+    "@rolldown/binding-freebsd-x64" "1.1.5"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.1.5"
+    "@rolldown/binding-linux-arm64-gnu" "1.1.5"
+    "@rolldown/binding-linux-arm64-musl" "1.1.5"
+    "@rolldown/binding-linux-ppc64-gnu" "1.1.5"
+    "@rolldown/binding-linux-s390x-gnu" "1.1.5"
+    "@rolldown/binding-linux-x64-gnu" "1.1.5"
+    "@rolldown/binding-linux-x64-musl" "1.1.5"
+    "@rolldown/binding-openharmony-arm64" "1.1.5"
+    "@rolldown/binding-wasm32-wasi" "1.1.5"
+    "@rolldown/binding-win32-arm64-msvc" "1.1.5"
+    "@rolldown/binding-win32-x64-msvc" "1.1.5"
+
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -4961,6 +5350,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -5011,6 +5405,11 @@ socks@^2.3.3:
   dependencies:
     ip-address "^9.0.5"
     smart-buffer "^4.2.0"
+
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-support@^0.5.21:
   version "0.5.21"
@@ -5085,10 +5484,20 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+std-env@^4.0.0-rc.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.2.0.tgz#8ebe0ec60485668ab47227b312f4254cdf80c9d3"
+  integrity sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==
 
 stdin-discarder@^0.2.2:
   version "0.2.2"
@@ -5298,6 +5707,29 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^1.0.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
+
+tinyglobby@^0.2.15, tinyglobby@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
+tinyrainbow@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
+  integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
 tldts-core@^6.1.85:
   version "6.1.85"
@@ -5620,6 +6052,45 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.1.4.tgz#3cd711f31de805e5154ab47948349e693314d581"
+  integrity sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==
+  dependencies:
+    lightningcss "^1.32.0"
+    picomatch "^4.0.5"
+    postcss "^8.5.16"
+    rolldown "~1.1.4"
+    tinyglobby "^0.2.17"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@4.1.10:
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.10.tgz#7e9285efe264b1167050b7a3a7ff34788e1b7afc"
+  integrity sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==
+  dependencies:
+    "@vitest/expect" "4.1.10"
+    "@vitest/mocker" "4.1.10"
+    "@vitest/pretty-format" "4.1.10"
+    "@vitest/runner" "4.1.10"
+    "@vitest/snapshot" "4.1.10"
+    "@vitest/spy" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running "^2.3.0"
+
 vm2@^3.9.17:
   version "3.9.19"
   resolved "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz#be1e1d7a106122c6c492b4d51c2e8b93d3ed6a4a"
@@ -5719,6 +6190,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 wide-align@^1.1.2:
   version "1.1.5"


### PR DESCRIPTION
## Summary

- add a 251-test Vitest behavior suite and CI coverage on Node 22.12 plus rolling Node 22
- fix command boundaries, provider routing, playlist/chapter handling, autocomplete allocation, queue insertion, SponsorBlock trimming, and voice ducking
- make Player playback/idle/voice transitions ownership-safe and isolate their concurrency state machines
- make cache publication/reconciliation concurrency-safe, validate startup config, and migrate the effective SQLite `DATABASE_URL`

## Validation

- `npm test` — 251/251
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- whole-branch correctness and maintainability reviews, including focused mutation/race tests

## Live acceptance

This is intentionally a draft until the exact `ghcr.io/museofficial/muse:pr-<number>` image is published and passes deployment plus controlled Discord acceptance.

A patch release is planned after successful live acceptance and merge.
